### PR TITLE
_otter_env_core.sh: do not clobber existing PERL5LIB

### DIFF
--- a/scripts/client/_otter_env_core.sh
+++ b/scripts/client/_otter_env_core.sh
@@ -120,7 +120,7 @@ then
 fi
 : ${otter_lib_perl5:=$OTTER_HOME/lib/perl5}
 
-PERL5LIB="\
+PERL5LIB="${PERL5LIB:+${PERL5LIB}:}\
 $anacode_perl_modules:\
 $ensembl_otter_home/modules:\
 $ensembl_home/ensembl/modules:\


### PR DESCRIPTION
As _otter_env_core.sh_ stands, running _otter_ overwrites whatever might have been present in $PERL5LIB. This is a problem _e.g._ if one uses this variable to make Perl aware of the install directory used by cpanminus. This PR ensures that the original value of PERL5LIB is preserved.

This is related to the _otter-client_ PR Ensembl/otter-client#1.