### PR TITLE
Fix the test for the XMLToRegion module

### DIFF
--- a/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
+++ b/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
@@ -5,7 +5,7 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
@@ -21,7 +21,7 @@
      <sequence_fragment>
        <id>KF456632.1.1.330</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>KF456632</accession>
        <version>1</version>
@@ -35,7 +35,7 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
@@ -51,7 +51,7 @@
      <sequence_fragment>
        <id>KF456630.1.1.371</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>KF456630</accession>
        <version>1</version>
@@ -65,7 +65,7 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
@@ -81,7 +81,7 @@
      <sequence_fragment>
        <id>KF456628.1.1.381</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>KF456628</accession>
        <version>1</version>
@@ -95,7 +95,7 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
@@ -111,7 +111,7 @@
      <sequence_fragment>
        <id>AC114808.4.1.176316</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>AC114808</accession>
        <version>4</version>
@@ -127,7 +127,7 @@
      <sequence_fragment>
        <id>AC225604.3.1.72250</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>AC225604</accession>
        <version>3</version>
@@ -141,7 +141,7 @@
      <sequence_fragment>
        <id>AC140476.2.1.172117</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>AC140476</accession>
        <version>2</version>
@@ -157,7 +157,7 @@
      <sequence_fragment>
        <id>AC108462.5.1.161648</id>
        <chromosome>2</chromosome>
-       <coord_system_name>contig</coord_system_name>
+       <coord_system_name>chromosome</coord_system_name>
        <coord_system_version>Otter</coord_system_version>
        <accession>AC108462</accession>
        <version>5</version>

--- a/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
+++ b/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
@@ -5,6 +5,8 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -19,6 +21,8 @@
      <sequence_fragment>
        <id>KF456632.1.1.330</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>KF456632</accession>
        <version>1</version>
        <clone_name>KF456632.1</clone_name>
@@ -31,6 +35,8 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -45,6 +51,8 @@
      <sequence_fragment>
        <id>KF456630.1.1.371</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>KF456630</accession>
        <version>1</version>
        <clone_name>KF456630.1</clone_name>
@@ -57,6 +65,8 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -71,6 +81,8 @@
      <sequence_fragment>
        <id>KF456628.1.1.381</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>KF456628</accession>
        <version>1</version>
        <clone_name>KF456628.1</clone_name>
@@ -83,6 +95,8 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -97,6 +111,8 @@
      <sequence_fragment>
        <id>AC114808.4.1.176316</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC114808</accession>
        <version>4</version>
        <clone_name>RP11-1268F2</clone_name>
@@ -111,6 +127,8 @@
      <sequence_fragment>
        <id>AC225604.3.1.72250</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC225604</accession>
        <version>3</version>
        <clone_name>CH16-67O12</clone_name>
@@ -123,6 +141,8 @@
      <sequence_fragment>
        <id>AC140476.2.1.172117</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC140476</accession>
        <version>2</version>
        <clone_name>RP11-1294H20</clone_name>
@@ -137,6 +157,8 @@
      <sequence_fragment>
        <id>AC108462.5.1.161648</id>
        <chromosome>2</chromosome>
+       <coord_system_name>contig</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC108462</accession>
        <version>5</version>
        <clone_name>RP13-542C4</clone_name>

--- a/t/lib/Test/Bio/Vega.pm
+++ b/t/lib/Test/Bio/Vega.pm
@@ -38,10 +38,23 @@ sub setup : Tests(setup) {
 # Overrideable - default is a plain in-memory one
 #
 sub get_coord_system_factory {
+    my ($test) = @_;
     require Bio::Vega::CoordSystemFactory;
-    return Bio::Vega::CoordSystemFactory->new;
+    return Bio::Vega::CoordSystemFactory->new(%{$test->get_coord_system_factory_override_spec});
 }
 
+sub get_coord_system_factory_override_spec {
+  my ($test) = @_;
+
+  return {
+    override_spec => {
+      chromosome => { '-version' => 'Otter', '-rank' => 2, '-default' => 1,                         },
+      clone      => {                        '-rank' => 4, '-default' => 1,                         },
+      contig     => {                        '-rank' => 5, '-default' => 1,                         },
+      dna_contig => { '-version' => 'Otter', '-rank' => 6, '-default' => 1, '-sequence_level' => 1, },
+    }
+  }
+}
 sub get_bio_vega_transform_xmltoregion {
     require Bio::Vega::Transform::XMLToRegion;
     return Bio::Vega::Transform::XMLToRegion->new;


### PR DESCRIPTION
The CoordSystemFactory module has been changed to not have the hard coded coord_systems.
I updated the data to add coord_system_name and coord_system_version to the XML file and I am providing a coord_system with override_spec