### PR TITLE
Bugfix/test changes

### DIFF
--- a/modules/Bio/Otter/Lace/Client.pm
+++ b/modules/Bio/Otter/Lace/Client.pm
@@ -971,9 +971,9 @@ sub get_meta {
 }
 
 sub get_db_info {
-    my ($self, $dsname, $ss) = @_;
-    my $hashref = $self->otter_response_content(GET => 'get_db_info', { dataset => $dsname, 'coord_system_name' => $ss->coord_system_name,
-                                                                         'coord_system_version' => $ss->coord_system_version, 'author' => $self->author });
+    my ($self, $dsname, $coord_system_name, $coord_system_version) = @_;
+    my $hashref = $self->otter_response_content(GET => 'get_db_info', { dataset => $dsname, 'coord_system_name' => $coord_system_name,
+                                                                         'coord_system_version' => $coord_system_version, 'author' => $self->author });
     return $hashref;
 }
 

--- a/modules/Bio/Otter/Lace/DataSet.pm
+++ b/modules/Bio/Otter/Lace/DataSet.pm
@@ -463,9 +463,14 @@ sub get_meta_value {
 sub db_info_hash {
     my ($self) = @_;
     # Get all db_info in one call
-    my $ss = $self->sequence_sets_cached->[0];
+    my $cs_name = 'chromosome';
+    my $cs_version = 'Otter';
+    if ($self->sequence_sets_cached) {
+      $cs_name = $self->sequence_sets_cached->[0]->coord_system_name;
+      $cs_version = $self->sequence_sets_cached->[0]->coord_system_version;
+    }
     return $self->{'_db_info_hash'} ||=
-        $self->Client->get_db_info($self->name, $ss);
+        $self->Client->get_db_info($self->name, $cs_name, $cs_version);
 }
 
 sub get_db_info_item {

--- a/modules/Bio/Vega/Transform/XMLToRegion.pm
+++ b/modules/Bio/Vega/Transform/XMLToRegion.pm
@@ -349,7 +349,7 @@ sub _build_Feature {            ## no critic (Subroutines::ProhibitUnusedPrivate
         -strand        => $data->{'strand'},
         -analysis      => $ana,
         -score         => $data->{'score'},
-        -display_label => $data->{'label'} | 'rank = filler',
+        -display_label => $data->{'label'} || 'rank = filler',
         -slice         => $chr_slice,
     );
     $region{$self}->add_seq_features($feature);

--- a/t/.OTC.get_db_info_response.109.human_test.txt
+++ b/t/.OTC.get_db_info_response.109.human_test.txt
@@ -1,0 +1,1958 @@
+{
+   "attrib_type" : [
+      {
+         "attrib_type_id" : "1",
+         "name" : "European Nucleotide Archive (was EMBL) accession",
+         "code" : "embl_acc",
+         "description" : null
+      },
+      {
+         "description" : null,
+         "code" : "status",
+         "name" : "Status",
+         "attrib_type_id" : "2"
+      },
+      {
+         "code" : "synonym",
+         "description" : null,
+         "attrib_type_id" : "3",
+         "name" : "Synonym"
+      },
+      {
+         "code" : "name",
+         "description" : "Alternative/long name",
+         "attrib_type_id" : "4",
+         "name" : "Name"
+      },
+      {
+         "code" : "type",
+         "description" : null,
+         "attrib_type_id" : "5",
+         "name" : "Type of feature"
+      },
+      {
+         "code" : "toplevel",
+         "description" : "Top Level Non-Redundant Sequence Region",
+         "attrib_type_id" : "6",
+         "name" : "Top Level"
+      },
+      {
+         "code" : "GeneCount",
+         "description" : "Total Number of Genes",
+         "attrib_type_id" : "7",
+         "name" : "Gene Count"
+      },
+      {
+         "code" : "KnownGeneCount",
+         "description" : "Total Number of Known Genes",
+         "attrib_type_id" : "8",
+         "name" : "Known Gene Count"
+      },
+      {
+         "name" : "PseudoGene Count",
+         "attrib_type_id" : "9",
+         "description" : "Total Number of PseudoGenes",
+         "code" : "PseudoGeneCount"
+      },
+      {
+         "code" : "SNPCount",
+         "description" : "Total Number of SNPs",
+         "attrib_type_id" : "10",
+         "name" : "Short Variants"
+      },
+      {
+         "name" : "Codon Table",
+         "attrib_type_id" : "11",
+         "description" : "Alternate codon table",
+         "code" : "codon_table"
+      },
+      {
+         "description" : null,
+         "code" : "_selenocysteine",
+         "name" : "Selenocysteine",
+         "attrib_type_id" : "12"
+      },
+      {
+         "name" : "bacend",
+         "attrib_type_id" : "13",
+         "description" : null,
+         "code" : "bacend"
+      },
+      {
+         "code" : "htg",
+         "description" : "High Throughput phase attribute",
+         "attrib_type_id" : "14",
+         "name" : "htg"
+      },
+      {
+         "attrib_type_id" : "15",
+         "name" : "Micro RNA",
+         "code" : "miRNA",
+         "description" : "Coordinates of the mature miRNA"
+      },
+      {
+         "attrib_type_id" : "16",
+         "name" : "Non Reference",
+         "code" : "non_ref",
+         "description" : "Non Reference Sequence Region"
+      },
+      {
+         "attrib_type_id" : "17",
+         "name" : "Sanger Project name",
+         "code" : "sanger_project",
+         "description" : null
+      },
+      {
+         "name" : "Clone name",
+         "attrib_type_id" : "18",
+         "description" : null,
+         "code" : "clone_name"
+      },
+      {
+         "description" : null,
+         "code" : "fish",
+         "name" : "FISH location",
+         "attrib_type_id" : "19"
+      },
+      {
+         "code" : "org",
+         "description" : null,
+         "attrib_type_id" : "21",
+         "name" : "Sequencing centre"
+      },
+      {
+         "description" : null,
+         "code" : "method",
+         "name" : "Method",
+         "attrib_type_id" : "22"
+      },
+      {
+         "name" : "Super contig id",
+         "attrib_type_id" : "23",
+         "description" : null,
+         "code" : "superctg"
+      },
+      {
+         "code" : "inner_start",
+         "description" : null,
+         "attrib_type_id" : "24",
+         "name" : "Max start value"
+      },
+      {
+         "name" : "Min end value",
+         "attrib_type_id" : "25",
+         "description" : null,
+         "code" : "inner_end"
+      },
+      {
+         "code" : "state",
+         "description" : null,
+         "attrib_type_id" : "26",
+         "name" : "Current state of clone"
+      },
+      {
+         "code" : "organisation",
+         "description" : null,
+         "attrib_type_id" : "27",
+         "name" : "Organisation sequencing clone"
+      },
+      {
+         "attrib_type_id" : "28",
+         "name" : "Accession length",
+         "code" : "seq_len",
+         "description" : null
+      },
+      {
+         "description" : null,
+         "code" : "fp_size",
+         "name" : "FP size",
+         "attrib_type_id" : "29"
+      },
+      {
+         "description" : null,
+         "code" : "BACend_flag",
+         "name" : "BAC end flags",
+         "attrib_type_id" : "30"
+      },
+      {
+         "name" : "fpc clone",
+         "attrib_type_id" : "31",
+         "description" : null,
+         "code" : "fpc_clone_id"
+      },
+      {
+         "description" : "Number of Known Protein Coding",
+         "code" : "KnwnPCCount",
+         "name" : "protein_coding_KNOWN",
+         "attrib_type_id" : "32"
+      },
+      {
+         "attrib_type_id" : "33",
+         "name" : "protein_coding_NOVEL",
+         "code" : "NovPCCount",
+         "description" : "Number of Novel Protein Coding"
+      },
+      {
+         "name" : "processed_transcript_NOVEL",
+         "attrib_type_id" : "34",
+         "description" : "Number of Novel Processed Transcripts",
+         "code" : "NovPTCount"
+      },
+      {
+         "description" : "Number of Putative Processed Transcripts",
+         "code" : "PutPTCount",
+         "name" : "processed_transcript_PUTATIVE",
+         "attrib_type_id" : "35"
+      },
+      {
+         "attrib_type_id" : "36",
+         "name" : "protein_coding_PREDICTED",
+         "code" : "PredPCCount",
+         "description" : "Number of Predicted Protein Coding"
+      },
+      {
+         "attrib_type_id" : "37",
+         "name" : "IG_gene",
+         "code" : "IGGeneCount",
+         "description" : "Number of IG Genes"
+      },
+      {
+         "attrib_type_id" : "38",
+         "name" : "IG_pseudogene",
+         "code" : "IGPsGenCount",
+         "description" : "Number of IG Pseudogenes"
+      },
+      {
+         "attrib_type_id" : "39",
+         "name" : "total_pseudogene",
+         "code" : "TotPsCount",
+         "description" : "Total Number of Pseudogenes"
+      },
+      {
+         "name" : "protein_coding_in_progress_KNOWN",
+         "attrib_type_id" : "42",
+         "description" : "Number of Known Protein Coding in progress",
+         "code" : "KnwnPCProgCount"
+      },
+      {
+         "code" : "NovPCProgCount",
+         "description" : "Number of Novel Protein Coding in progress",
+         "attrib_type_id" : "43",
+         "name" : "protein_coding_in_progress_NOVEL"
+      },
+      {
+         "name" : "Annotated sequence length",
+         "attrib_type_id" : "44",
+         "description" : "Annotated Sequence",
+         "code" : "AnnotSeqLength"
+      },
+      {
+         "attrib_type_id" : "45",
+         "name" : "Total number of clones",
+         "code" : "TotCloneNum",
+         "description" : "Total Number of Clones"
+      },
+      {
+         "description" : "Number of Fully Annotated Clones",
+         "code" : "NumAnnotClone",
+         "name" : "Fully annotated clones",
+         "attrib_type_id" : "46"
+      },
+      {
+         "attrib_type_id" : "47",
+         "name" : "Acknowledgement",
+         "code" : "ack",
+         "description" : "Acknowledgement for manual annotation"
+      },
+      {
+         "name" : "High throughput phase",
+         "attrib_type_id" : "48",
+         "description" : "High throughput genomic sequencing phase",
+         "code" : "htg_phase"
+      },
+      {
+         "attrib_type_id" : "49",
+         "name" : "Description",
+         "code" : "description",
+         "description" : "A general descriptive text attribute"
+      },
+      {
+         "code" : "chromosome",
+         "description" : "Chromosomal location for supercontigs that are not assembled",
+         "attrib_type_id" : "50",
+         "name" : "Chromosome"
+      },
+      {
+         "code" : "nonsense",
+         "description" : "Strain specific nonesense mutation",
+         "attrib_type_id" : "51",
+         "name" : "Nonsense Mutation"
+      },
+      {
+         "code" : "author",
+         "description" : "Group resonsible for Vega annotation",
+         "attrib_type_id" : "52",
+         "name" : "Author"
+      },
+      {
+         "description" : "Author email address",
+         "code" : "author_email",
+         "name" : "Author email address",
+         "attrib_type_id" : "53"
+      },
+      {
+         "description" : "Annotation remark",
+         "code" : "remark",
+         "name" : "Remark",
+         "attrib_type_id" : "54"
+      },
+      {
+         "code" : "transcr_class",
+         "description" : "Transcript class",
+         "attrib_type_id" : "55",
+         "name" : "Transcript class"
+      },
+      {
+         "code" : "KnwnPTCount",
+         "description" : "Number of Known Processed Transcripts",
+         "attrib_type_id" : "56",
+         "name" : "processed_transcript_KNOWN"
+      },
+      {
+         "code" : "ccds",
+         "description" : "CCDS identifier",
+         "attrib_type_id" : "57",
+         "name" : "CCDS"
+      },
+      {
+         "attrib_type_id" : "58",
+         "name" : "CCDS Public Note",
+         "code" : "CCDS_PublicNote",
+         "description" : "Public Note for CCDS identifier, provided by http://www.ncbi.nlm.nih.gov/CCDS"
+      },
+      {
+         "description" : "Frameshift modelled as intron",
+         "code" : "Frameshift",
+         "name" : "Frameshift",
+         "attrib_type_id" : "59"
+      },
+      {
+         "attrib_type_id" : "60",
+         "name" : "processed_transcript",
+         "code" : "PTCount",
+         "description" : "Number of Processed Transcripts"
+      },
+      {
+         "code" : "PredPTCount",
+         "description" : "Number of Predicted Processed Transcripts",
+         "attrib_type_id" : "61",
+         "name" : "processed_transcript_PREDICTED"
+      },
+      {
+         "name" : "Structure",
+         "attrib_type_id" : "62",
+         "description" : "RNA secondary structure line",
+         "code" : "ncRNA"
+      },
+      {
+         "description" : null,
+         "code" : "skip_clone",
+         "name" : "skip clone  Skip clone in align_by_clone_identity.pl",
+         "attrib_type_id" : "63"
+      },
+      {
+         "attrib_type_id" : "64",
+         "name" : "Coding genes",
+         "code" : "coding_cnt",
+         "description" : "Number of protein coding Genes"
+      },
+      {
+         "code" : "GeneNo_novCod",
+         "description" : "Number of novel protein_coding Genes",
+         "attrib_type_id" : "65",
+         "name" : "novel protein_coding Gene Count"
+      },
+      {
+         "description" : "Number of rRNA Genes",
+         "code" : "GeneNo_rRNA",
+         "name" : "rRNA Gene Count",
+         "attrib_type_id" : "66"
+      },
+      {
+         "description" : "Number of pseudogenes",
+         "code" : "pseudogene_cnt",
+         "name" : "Pseudogenes",
+         "attrib_type_id" : "67"
+      },
+      {
+         "code" : "GeneNo_snRNA",
+         "description" : "Number of snRNA Genes",
+         "attrib_type_id" : "68",
+         "name" : "snRNA Gene Count"
+      },
+      {
+         "attrib_type_id" : "69",
+         "name" : "snoRNA Gene Count",
+         "code" : "GeneNo_snoRNA",
+         "description" : "Number of snoRNA Genes"
+      },
+      {
+         "name" : "miRNA Gene Count",
+         "attrib_type_id" : "70",
+         "description" : "Number of miRNA Genes",
+         "code" : "GeneNo_miRNA"
+      },
+      {
+         "attrib_type_id" : "71",
+         "name" : "misc_RNA Gene Count",
+         "code" : "GeneNo_mscRNA",
+         "description" : "Number of misc_RNA Genes"
+      },
+      {
+         "description" : "Number of scRNA Genes",
+         "code" : "GeneNo_scRNA",
+         "name" : "scRNA Gene Count",
+         "attrib_type_id" : "72"
+      },
+      {
+         "description" : "Number of Mt_rRNA Genes",
+         "code" : "GeneNo_MTrRNA",
+         "name" : "Mt_rRNA Gene Count",
+         "attrib_type_id" : "73"
+      },
+      {
+         "description" : "Number of Mt_tRNA Genes",
+         "code" : "GeneNo_MTtRNA",
+         "name" : "Mt_tRNA Gene Count",
+         "attrib_type_id" : "74"
+      },
+      {
+         "attrib_type_id" : "75",
+         "name" : "RNA_pseudogene Gene Count",
+         "code" : "GeneNo_RNA_pseu",
+         "description" : "Number of RNA_pseudogene Genes"
+      },
+      {
+         "attrib_type_id" : "76",
+         "name" : "tRNA Gene Count",
+         "code" : "GeneNo_tRNA",
+         "description" : "Number of tRNA Genes"
+      },
+      {
+         "code" : "GeneNo_rettran",
+         "description" : "Number of retrotransposed Genes",
+         "attrib_type_id" : "77",
+         "name" : "retrotransposed Gene Count"
+      },
+      {
+         "code" : "GeneNo_snlRNA",
+         "description" : "Number of snlRNA Genes",
+         "attrib_type_id" : "78",
+         "name" : "snlRNA Gene Count"
+      },
+      {
+         "name" : "processed_transcript Gene Count",
+         "attrib_type_id" : "79",
+         "description" : "Number of processed transcript Genes",
+         "code" : "GeneNo_proc_tr"
+      },
+      {
+         "code" : "supercontig",
+         "description" : null,
+         "attrib_type_id" : "80",
+         "name" : "SuperContig name"
+      },
+      {
+         "description" : null,
+         "code" : "well_name",
+         "name" : "Well plate name",
+         "attrib_type_id" : "81"
+      },
+      {
+         "code" : "bacterial",
+         "description" : null,
+         "attrib_type_id" : "82",
+         "name" : "Bacterial"
+      },
+      {
+         "name" : "Novel CDS Count",
+         "attrib_type_id" : "83",
+         "description" : null,
+         "code" : "NovelCDSCount"
+      },
+      {
+         "name" : "Novel Transcript Count",
+         "attrib_type_id" : "84",
+         "description" : null,
+         "code" : "NovelTransCount"
+      },
+      {
+         "attrib_type_id" : "85",
+         "name" : "Putative Transcript Count",
+         "code" : "PutTransCount",
+         "description" : null
+      },
+      {
+         "description" : null,
+         "code" : "PredTransCount",
+         "name" : "Predicted Transcript Count",
+         "attrib_type_id" : "86"
+      },
+      {
+         "code" : "UnclassPsCount",
+         "description" : null,
+         "attrib_type_id" : "87",
+         "name" : "Unclass Ps count"
+      },
+      {
+         "attrib_type_id" : "88",
+         "name" : "Known prog Count",
+         "code" : "KnwnprogCount",
+         "description" : null
+      },
+      {
+         "description" : null,
+         "code" : "NovCDSprogCount",
+         "name" : "Novel CDS prog count",
+         "attrib_type_id" : "89"
+      },
+      {
+         "name" : "BACend well name",
+         "attrib_type_id" : "90",
+         "description" : null,
+         "code" : "bacend_well_nam"
+      },
+      {
+         "description" : null,
+         "code" : "alt_well_name",
+         "name" : "Alt well name",
+         "attrib_type_id" : "91"
+      },
+      {
+         "name" : "Transcript Edge",
+         "attrib_type_id" : "92",
+         "description" : null,
+         "code" : "TranscriptEdge"
+      },
+      {
+         "name" : "Alt European Nucleotide Archive (was EMBL) acc",
+         "attrib_type_id" : "93",
+         "description" : null,
+         "code" : "alt_embl_acc"
+      },
+      {
+         "name" : "Alt org",
+         "attrib_type_id" : "94",
+         "description" : null,
+         "code" : "alt_org"
+      },
+      {
+         "attrib_type_id" : "95",
+         "name" : "International Clone Name",
+         "code" : "intl_clone_name",
+         "description" : null
+      },
+      {
+         "name" : "European Nucleotide Archive (was EMBL) Version",
+         "attrib_type_id" : "96",
+         "description" : null,
+         "code" : "embl_version"
+      },
+      {
+         "name" : "Chromosome Name",
+         "attrib_type_id" : "97",
+         "description" : "Chromosome Name Contained in the Assembly",
+         "code" : "chr"
+      },
+      {
+         "name" : "Equivalent EnsEMBL assembly",
+         "attrib_type_id" : "98",
+         "description" : "For full chromosomes made from NCBI AGPs",
+         "code" : "equiv_asm"
+      },
+      {
+         "name" : "ncRNA Gene Count",
+         "attrib_type_id" : "99",
+         "description" : "Number of ncRNA Genes",
+         "code" : "GeneNo_ncRNA"
+      },
+      {
+         "name" : "Ig Gene Count",
+         "attrib_type_id" : "100",
+         "description" : "Number of Ig Genes",
+         "code" : "GeneNo_Ig"
+      },
+      {
+         "name" : "hit similarity",
+         "attrib_type_id" : "109",
+         "description" : "percentage id to parent transcripts",
+         "code" : "HitSimilarity"
+      },
+      {
+         "name" : "hit coverage",
+         "attrib_type_id" : "110",
+         "description" : "coverage of parent transcripts",
+         "code" : "HitCoverage"
+      },
+      {
+         "code" : "PropNonGap",
+         "description" : "proportion non gap",
+         "attrib_type_id" : "111",
+         "name" : "proportion non gap"
+      },
+      {
+         "attrib_type_id" : "112",
+         "name" : "number of stops",
+         "code" : "NumStops",
+         "description" : null
+      },
+      {
+         "attrib_type_id" : "113",
+         "name" : "gap exons",
+         "code" : "GapExons",
+         "description" : "number of gap exons"
+      },
+      {
+         "code" : "SourceTran",
+         "description" : "source transcript",
+         "attrib_type_id" : "114",
+         "name" : "source transcript"
+      },
+      {
+         "name" : "end not found",
+         "attrib_type_id" : "115",
+         "description" : "end not found",
+         "code" : "EndNotFound"
+      },
+      {
+         "description" : "start not found",
+         "code" : "StartNotFound",
+         "name" : "start not found",
+         "attrib_type_id" : "116"
+      },
+      {
+         "description" : null,
+         "code" : "Frameshift Fra",
+         "name" : "Frameshift modelled as intron",
+         "attrib_type_id" : "117"
+      },
+      {
+         "name" : "Ensembl name",
+         "attrib_type_id" : "118",
+         "description" : "Name of equivalent Ensembl chromosome",
+         "code" : "ensembl_name"
+      },
+      {
+         "name" : "NoAnnotation",
+         "attrib_type_id" : "119",
+         "description" : "Clones without manual annotation",
+         "code" : "NoAnnotation"
+      },
+      {
+         "description" : "Contig present on a haplotype",
+         "code" : "hap_contig",
+         "name" : "Haplotype contig",
+         "attrib_type_id" : "120"
+      },
+      {
+         "code" : "annotated",
+         "description" : null,
+         "attrib_type_id" : "121",
+         "name" : "Clone Annotation Status"
+      },
+      {
+         "code" : "keyword",
+         "description" : null,
+         "attrib_type_id" : "122",
+         "name" : "Clone Keyword"
+      },
+      {
+         "description" : null,
+         "code" : "hidden_remark",
+         "name" : "Hidden Remark",
+         "attrib_type_id" : "123"
+      },
+      {
+         "description" : null,
+         "code" : "mRNA_start_NF",
+         "name" : "mRNA start not found",
+         "attrib_type_id" : "124"
+      },
+      {
+         "description" : null,
+         "code" : "mRNA_end_NF",
+         "name" : "mRNA end not found",
+         "attrib_type_id" : "125"
+      },
+      {
+         "name" : "CDS start not found",
+         "attrib_type_id" : "126",
+         "description" : null,
+         "code" : "cds_start_NF"
+      },
+      {
+         "attrib_type_id" : "127",
+         "name" : "CDS end not found",
+         "code" : "cds_end_NF",
+         "description" : null
+      },
+      {
+         "description" : "1 for writable , 0 for read-only",
+         "code" : "write_access",
+         "name" : "Write access for Sequence Set",
+         "attrib_type_id" : "128"
+      },
+      {
+         "name" : "Hidden Sequence Set",
+         "attrib_type_id" : "129",
+         "description" : null,
+         "code" : "hidden"
+      },
+      {
+         "attrib_type_id" : "130",
+         "name" : "Vega name",
+         "code" : "vega_name",
+         "description" : "Vega seq_region.name"
+      },
+      {
+         "attrib_type_id" : "131",
+         "name" : "Export mode",
+         "code" : "vega_export_mod",
+         "description" : "E (External), I (Internal) etc"
+      },
+      {
+         "name" : "Vega release",
+         "attrib_type_id" : "132",
+         "description" : "Vega release number",
+         "code" : "vega_release"
+      },
+      {
+         "name" : "Clone_left_end",
+         "attrib_type_id" : "133",
+         "description" : "Clone_lef_end feature marked in GAP database",
+         "code" : "atag_CLE"
+      },
+      {
+         "name" : "Clone_right_end",
+         "attrib_type_id" : "134",
+         "description" : "Clone_right_end feature marked in GAP database",
+         "code" : "atag_CRE"
+      },
+      {
+         "code" : "atag_Misc",
+         "description" : "miscellaneous feature marked in GAP database",
+         "attrib_type_id" : "135",
+         "name" : "Misc"
+      },
+      {
+         "description" : "region of uncertain DNA sequence marked in GAP database",
+         "code" : "atag_Unsure",
+         "name" : "Unsure",
+         "attrib_type_id" : "136"
+      },
+      {
+         "code" : "MultAssem",
+         "description" : "Part of Seq Region is part of more than one assembly",
+         "attrib_type_id" : "137",
+         "name" : "Multiple Assembled seq region"
+      },
+      {
+         "name" : "WGS contig",
+         "attrib_type_id" : "140",
+         "description" : "WGS contig integrated into the map",
+         "code" : "wgs"
+      },
+      {
+         "code" : "bac",
+         "description" : "tiling path of clones",
+         "attrib_type_id" : "141",
+         "name" : "AGP clones"
+      },
+      {
+         "attrib_type_id" : "142",
+         "name" : "Gene GC",
+         "code" : "GeneGC",
+         "description" : "Percentage GC content for this gene"
+      },
+      {
+         "code" : "TotAssemblyLeng",
+         "description" : "Length of the assembly not counting sequence gaps",
+         "attrib_type_id" : "143",
+         "name" : "Finished sequence length"
+      },
+      {
+         "code" : "amino_acid_sub",
+         "description" : "Some translations have been manually curated for amino acid substitiutions. For example a stop codon may be changed to an amino acid in order to prevent premature truncation, or one amino acid can be substituted for another.",
+         "attrib_type_id" : "144",
+         "name" : "Amino acid substitution"
+      },
+      {
+         "code" : "_rna_edit",
+         "description" : "RNA edit",
+         "attrib_type_id" : "145",
+         "name" : "rna_edit"
+      },
+      {
+         "description" : "Reason why a transcript has been killed",
+         "code" : "kill_reason",
+         "name" : "Kill Reason",
+         "attrib_type_id" : "146"
+      },
+      {
+         "code" : "strip_UTR",
+         "description" : "Transcript needs bad UTR removing",
+         "attrib_type_id" : "147",
+         "name" : "Strip UTR"
+      },
+      {
+         "description" : "Finished Sequence",
+         "code" : "TotAssLength",
+         "name" : "Finished sequence length",
+         "attrib_type_id" : "148"
+      },
+      {
+         "code" : "PsCount",
+         "description" : "Number of Pseudogenes",
+         "attrib_type_id" : "149",
+         "name" : "pseudogene"
+      },
+      {
+         "attrib_type_id" : "152",
+         "name" : "total_processed_transcript",
+         "code" : "TotPTCount",
+         "description" : "Total Number of Processed Transcripts"
+      },
+      {
+         "name" : "total_protein_coding",
+         "attrib_type_id" : "153",
+         "description" : "Total Number of Protein Coding",
+         "code" : "TotPCCount"
+      },
+      {
+         "attrib_type_id" : "154",
+         "name" : "novel_non_coding",
+         "code" : "NovNcCount",
+         "description" : "Number of Novel Non Coding"
+      },
+      {
+         "description" : "Number of Known Polymorphic Pseudogenes",
+         "code" : "KnwnPolyPsCount",
+         "name" : "known_polymorphic",
+         "attrib_type_id" : "155"
+      },
+      {
+         "attrib_type_id" : "156",
+         "name" : "polymorphic_pseudogene",
+         "code" : "PolyPsCount",
+         "description" : "Number of Polymorphic Pseudogenes"
+      },
+      {
+         "attrib_type_id" : "157",
+         "name" : "total_IG_gene",
+         "code" : "TotIGGeneCount",
+         "description" : "Total Number of IG Genes"
+      },
+      {
+         "description" : "Number of Processed Pseudogenes",
+         "code" : "ProcPsCount",
+         "name" : "proc_pseudogene",
+         "attrib_type_id" : "158"
+      },
+      {
+         "code" : "UnPsCount",
+         "description" : "Number of Unprocessed Pseudogenes",
+         "attrib_type_id" : "159",
+         "name" : "unproc_pseudogene"
+      },
+      {
+         "description" : "Number of Transcribed Pseudogenes",
+         "code" : "TPsCount",
+         "name" : "transcribed_pseudogene",
+         "attrib_type_id" : "160"
+      },
+      {
+         "description" : "Number of TEC Genes",
+         "code" : "TECCount",
+         "name" : "TEC",
+         "attrib_type_id" : "161"
+      },
+      {
+         "description" : "Number of Known IG Genes",
+         "code" : "KnwnIGGeneCount",
+         "name" : "IG_gene_KNOWN",
+         "attrib_type_id" : "162"
+      },
+      {
+         "description" : "Number of Known IG Pseudogenes",
+         "code" : "KnwnIGPsGeCount",
+         "name" : "IG_pseudogene_KNOWN",
+         "attrib_type_id" : "163"
+      },
+      {
+         "attrib_type_id" : "164",
+         "name" : "Isoelectric point",
+         "code" : "IsoPoint",
+         "description" : "Pepstats attributes"
+      },
+      {
+         "description" : "Pepstats attributes",
+         "code" : "Charge",
+         "name" : "Charge",
+         "attrib_type_id" : "165"
+      },
+      {
+         "description" : "Pepstats attributes",
+         "code" : "MolecularWeight",
+         "name" : "Molecular weight",
+         "attrib_type_id" : "166"
+      },
+      {
+         "code" : "NumResidues",
+         "description" : "Pepstats attributes",
+         "attrib_type_id" : "167",
+         "name" : "Number of residues"
+      },
+      {
+         "attrib_type_id" : "168",
+         "name" : "Ave. residue weight",
+         "code" : "AvgResWeight",
+         "description" : "Pepstats attributes"
+      },
+      {
+         "attrib_type_id" : "170",
+         "name" : "Initial methionine",
+         "code" : "initial_met",
+         "description" : "Set first amino acid to methionine"
+      },
+      {
+         "code" : "NonGapHCov",
+         "description" : null,
+         "attrib_type_id" : "171",
+         "name" : "NonGapHCov"
+      },
+      {
+         "attrib_type_id" : "172",
+         "name" : "otter support",
+         "code" : "otter_support",
+         "description" : "Evidence ID that was used as supporting feature for building a gene in Vega"
+      },
+      {
+         "name" : "enst link",
+         "attrib_type_id" : "173",
+         "description" : "Code to link a OTTT with an ENST when they both share the CDS of ENST",
+         "code" : "enst_link"
+      },
+      {
+         "name" : "upstream ATG",
+         "attrib_type_id" : "174",
+         "description" : "Alternative ATG found upstream of the defined as start ATG for the transcript",
+         "code" : "upstream_ATG"
+      },
+      {
+         "code" : "TPPsCount",
+         "description" : "Number of Transcribed Processed Pseudogenes",
+         "attrib_type_id" : "175",
+         "name" : "transcribed_processed_pseudogene"
+      },
+      {
+         "description" : "Number of Transcribed Unprocessed Pseudogenes",
+         "code" : "TUPsCount",
+         "name" : "transcribed_unprocessed_pseudogene",
+         "attrib_type_id" : "176"
+      },
+      {
+         "name" : "unitary_pseudogene",
+         "attrib_type_id" : "177",
+         "description" : "Number of Unitary Pseudogenes",
+         "code" : "UniPsCount"
+      },
+      {
+         "name" : "TEC_KNOWN",
+         "attrib_type_id" : "178",
+         "description" : "Number of Known TEC genes",
+         "code" : "KnwnTECCount"
+      },
+      {
+         "description" : "Total number of TEC genes",
+         "code" : "TotTECGeneCount",
+         "name" : "TEC_all",
+         "attrib_type_id" : "179"
+      },
+      {
+         "name" : "transcribed_unitary_pseudogene",
+         "attrib_type_id" : "180",
+         "description" : "Number of Transcribed Unitary Pseudogenes",
+         "code" : "TUyPsCount"
+      },
+      {
+         "name" : "polymorphic",
+         "attrib_type_id" : "181",
+         "description" : "Number of Polymorphic Genes",
+         "code" : "PolyCount"
+      },
+      {
+         "name" : "polymorphic",
+         "attrib_type_id" : "182",
+         "description" : "Number of Known Polymorphic Genes",
+         "code" : "KnwnPolyCount"
+      },
+      {
+         "attrib_type_id" : "183",
+         "name" : "TR_gene_known",
+         "code" : "KnwnTRCount",
+         "description" : "Number of Known TR Genes"
+      },
+      {
+         "attrib_type_id" : "184",
+         "name" : "TR_gene",
+         "code" : "TRGeneCount",
+         "description" : "Number of TR Genes"
+      },
+      {
+         "attrib_type_id" : "185",
+         "name" : "TR_pseudo",
+         "code" : "TRPsCount",
+         "description" : "Number of TR Pseudogenes"
+      },
+      {
+         "code" : "tp_ott_support",
+         "description" : "Evidence ID that was used as supporting feature for building a gene in Vega",
+         "attrib_type_id" : "186",
+         "name" : "otter protein transcript support"
+      },
+      {
+         "code" : "td_ott_support",
+         "description" : "Evidence ID that was used as supporting feature for building a gene in Vega",
+         "attrib_type_id" : "187",
+         "name" : "otter dna transcript support"
+      },
+      {
+         "name" : "otter protein exon support",
+         "attrib_type_id" : "188",
+         "description" : "Evidence ID that was used as supporting feature for building a gene in Vega",
+         "code" : "ep_ott_support"
+      },
+      {
+         "attrib_type_id" : "189",
+         "name" : "otter dna exon support",
+         "code" : "ed_ott_support",
+         "description" : "Evidence ID that was used as supporting feature for building a gene in Vega"
+      },
+      {
+         "code" : "GeneNo_lincRNA",
+         "description" : "Number of lincRNA Genes",
+         "attrib_type_id" : "190",
+         "name" : "lincRNA Gene Count"
+      },
+      {
+         "description" : "This transcript has a variant that causes a stop codon to be gained in at least 10 percent of a HapMap population",
+         "code" : "StopGained",
+         "name" : "SNP causes stop codon to be gained",
+         "attrib_type_id" : "191"
+      },
+      {
+         "description" : "This transcript has a variant that causes a stop codon to be lost in at least 10 percent of a HapMap population",
+         "code" : "StopLost",
+         "name" : "SNP causes stop codon to be lost",
+         "attrib_type_id" : "192"
+      },
+      {
+         "attrib_type_id" : "193",
+         "name" : "class_I_RNA Gene Count",
+         "code" : "GeneNo_class_I_",
+         "description" : "Number of class_I_RNA Genes"
+      },
+      {
+         "code" : "GeneNo_SRP_RNA",
+         "description" : "Number of SRP_RNA Genes",
+         "attrib_type_id" : "194",
+         "name" : "SRP_RNA Gene Count"
+      },
+      {
+         "name" : "class_II_RNA Gene Count",
+         "attrib_type_id" : "195",
+         "description" : "Number of class_II_RNA Genes",
+         "code" : "GeneNo_class_II"
+      },
+      {
+         "attrib_type_id" : "196",
+         "name" : "RNase_P_RNA Gene Count",
+         "code" : "GeneNo_P_RNA",
+         "description" : "Number of RNase_P_RNA Genes"
+      },
+      {
+         "name" : "RNase_MRP_RNA Gene Count",
+         "attrib_type_id" : "197",
+         "description" : "Number of RNase_MRP_RNA Genes",
+         "code" : "GeneNo_RNase_MR"
+      },
+      {
+         "description" : "Frameshift on the query sequence is lost in the target sequence",
+         "code" : "lost_frameshift",
+         "name" : "lost_frameshift",
+         "attrib_type_id" : "198"
+      },
+      {
+         "description" : "The position of other possible three prime ends for the transcript",
+         "code" : "AltThreePrime",
+         "name" : "Alternate three prime end",
+         "attrib_type_id" : "199"
+      },
+      {
+         "attrib_type_id" : "216",
+         "name" : "Gene in LRG",
+         "code" : "GeneInLRG",
+         "description" : "This gene is contained within an LRG region"
+      },
+      {
+         "code" : "GeneOverlapLRG",
+         "description" : "This gene is partially overlapped by a LRG region (start or end outside LRG)",
+         "attrib_type_id" : "217",
+         "name" : "Gene overlaps LRG"
+      },
+      {
+         "name" : "readthrough transcript",
+         "attrib_type_id" : "218",
+         "description" : "Havana readthrough transcripts",
+         "code" : "readthrough_tra"
+      },
+      {
+         "name" : "Constitutive exon",
+         "attrib_type_id" : "300",
+         "description" : "An exon that is always included in the mature mRNA, even in different mRNA isoforms",
+         "code" : "CNE"
+      },
+      {
+         "code" : "CE",
+         "description" : "One exon is spliced out of the primary transcript together with its flanking introns",
+         "attrib_type_id" : "301",
+         "name" : "Cassette exon"
+      },
+      {
+         "code" : "IR",
+         "description" : "A sequence is spliced out as an intron or remains in the mature mRNA transcript",
+         "attrib_type_id" : "302",
+         "name" : "Intron retention"
+      },
+      {
+         "name" : "Mutually exclusive exons",
+         "attrib_type_id" : "303",
+         "description" : "In the simpliest case, one or two consecutive exons are retained but not both",
+         "code" : "MXE"
+      },
+      {
+         "name" : "Alternative 3' sites",
+         "attrib_type_id" : "304",
+         "description" : "Two or more splice sites are recognized at the 5' end of an exon. An alternative 3' splice junction (acceptor site) is used, changing the 5' boundary of the downstream exon",
+         "code" : "A3SS"
+      },
+      {
+         "attrib_type_id" : "305",
+         "name" : "Alternative 5' sites",
+         "code" : "A5SS",
+         "description" : "Two or more splice sites are recognized at the 3' end of an exon. An alternative 5' splice junction (donor site) is used, changing the 3' boundary of the upstream exon"
+      },
+      {
+         "code" : "AFE",
+         "description" : "The second exons of each variant have identical boundaries, but the first exons do not overlap",
+         "attrib_type_id" : "306",
+         "name" : "Alternative first exon"
+      },
+      {
+         "attrib_type_id" : "307",
+         "name" : "Alternative last exon",
+         "code" : "ALE",
+         "description" : "Penultimate exons of each splice variant have identical boundaries, but the last exons do not overlap"
+      },
+      {
+         "attrib_type_id" : "308",
+         "name" : "Intron isoform",
+         "code" : "II",
+         "description" : "Alternative donor or acceptor splice sites lead to truncation or extension of introns, respectively"
+      },
+      {
+         "description" : "Alternative donor or acceptor splice sites leads to truncation or extension of exons, respectively",
+         "code" : "EI",
+         "name" : "Exon isoform",
+         "attrib_type_id" : "309"
+      },
+      {
+         "attrib_type_id" : "310",
+         "name" : "Alternative initiation",
+         "code" : "AI",
+         "description" : "Alternative choice of promoters"
+      },
+      {
+         "description" : "Alternative choice of polyadenylation sites",
+         "code" : "AT",
+         "name" : "Alternative termination",
+         "attrib_type_id" : "311"
+      },
+      {
+         "name" : "Assembly Patch Fix",
+         "attrib_type_id" : "312",
+         "description" : "Assembly patch that will, in the next assembly release, replace the corresponding sequence found in the current assembly",
+         "code" : "patch_fix"
+      },
+      {
+         "description" : "Assembly patch that will, in the next assembly release, be retained as an alternate non-reference sequence in a similar way to haplotypes",
+         "code" : "patch_novel",
+         "name" : "Assembly Patch Novel",
+         "attrib_type_id" : "313"
+      },
+      {
+         "code" : "LRG",
+         "description" : "Locus Reference Genomic sequence",
+         "attrib_type_id" : "314",
+         "name" : "Locus Reference Genomic"
+      },
+      {
+         "name" : "Evidence for transcript removed",
+         "attrib_type_id" : "315",
+         "description" : "Supporting evidence for this projected transcript has been removed",
+         "code" : "NoEvidence"
+      },
+      {
+         "name" : "Circular sequence",
+         "attrib_type_id" : "316",
+         "description" : "Circular chromosome or plasmid molecule",
+         "code" : "circular_seq"
+      },
+      {
+         "code" : "external_db",
+         "description" : "External database to which seq_region name may be linked",
+         "attrib_type_id" : "317",
+         "name" : "External database"
+      },
+      {
+         "attrib_type_id" : "318",
+         "name" : "split_tscript",
+         "code" : "split_tscript",
+         "description" : "split_tscript"
+      },
+      {
+         "code" : "Threep",
+         "description" : "Alternate three prime end",
+         "attrib_type_id" : "319",
+         "name" : "Three prime end"
+      },
+      {
+         "code" : "gene_cluster",
+         "description" : "Havana annotated gene cluster",
+         "attrib_type_id" : "320",
+         "name" : "Gene cluster"
+      },
+      {
+         "attrib_type_id" : "328",
+         "name" : "Ribosomal Frameshift",
+         "code" : "_rib_frameshift",
+         "description" : "Position and magnitude of frameshift"
+      },
+      {
+         "description" : "Haplotypes reference a regular chromosome (indicated in the value of the attribute)",
+         "code" : "vega_ref_chrom",
+         "name" : "Vega reference chromosome",
+         "attrib_type_id" : "345"
+      },
+      {
+         "description" : "Number of Putative Protein Coding",
+         "code" : "PutPCCount",
+         "name" : "protein_coding_PUTATIVE",
+         "attrib_type_id" : "346"
+      },
+      {
+         "code" : "proj_alt_seq",
+         "description" : "Projected sequence differs from original",
+         "attrib_type_id" : "347",
+         "name" : "Projection altered sequence"
+      },
+      {
+         "description" : "Gene biotype assigned by Havana",
+         "code" : "hav_gene_type",
+         "name" : "Havana gene biotype",
+         "attrib_type_id" : "348"
+      },
+      {
+         "code" : "GeneNo_antisense",
+         "description" : "Number of antisense Genes",
+         "attrib_type_id" : "349",
+         "name" : "antisense Gene Count"
+      },
+      {
+         "code" : "GeneNo_sense_in",
+         "description" : "Number of sense_intronic Genes",
+         "attrib_type_id" : "350",
+         "name" : "sense_intronic Gene Count"
+      },
+      {
+         "description" : "Number of ambiguous_orf Genes",
+         "code" : "GeneNo_amb_orf",
+         "name" : "ambiguous_orf Gene Count",
+         "attrib_type_id" : "351"
+      },
+      {
+         "attrib_type_id" : "352",
+         "name" : "retained_intron Gene Count",
+         "code" : "GeneNo_ret_int",
+         "description" : "Number of retained_intron Genes"
+      },
+      {
+         "attrib_type_id" : "353",
+         "name" : "Non coding gene count",
+         "code" : "noncoding_cnt",
+         "description" : "Number of non coding genes"
+      },
+      {
+         "code" : "GeneNo_ncrna_h",
+         "description" : "Number of ncrna_host Genes",
+         "attrib_type_id" : "354",
+         "name" : "ncrna_host Gene Count"
+      },
+      {
+         "attrib_type_id" : "355",
+         "name" : "sense_overlapping Gene Count",
+         "code" : "GeneNo_sens_ov",
+         "description" : "Number of sense_overlapping Genes"
+      },
+      {
+         "name" : "3prime_overlapping Gene Count",
+         "attrib_type_id" : "356",
+         "description" : "Number of 3prime_overlapping Genes",
+         "code" : "GeneNo_3prime"
+      },
+      {
+         "description" : "Number of tmRNA Genes",
+         "code" : "GeneNo_tmRNA",
+         "name" : "tmRNA Gene Count",
+         "attrib_type_id" : "357"
+      },
+      {
+         "code" : "PHIbase_mutant",
+         "description" : "PHI-base phenotype of the mutants",
+         "attrib_type_id" : "358",
+         "name" : "PHI-base mutant"
+      },
+      {
+         "description" : "Number of ribozyme Genes",
+         "code" : "GeneNo_ribozyme",
+         "name" : "ribozyme Gene Count",
+         "attrib_type_id" : "359"
+      },
+      {
+         "name" : "ncrna_host",
+         "attrib_type_id" : "360",
+         "description" : "Havana ncrna_host gene",
+         "code" : "ncrna_host"
+      },
+      {
+         "description" : "The classification of the gene or transcript based on alignment to NR (values: TE WH NH)",
+         "code" : "peptide-class",
+         "name" : "Peptide classification",
+         "attrib_type_id" : "361"
+      },
+      {
+         "description" : "High-confidence set of genes, composed of evidence-based genes and non-overlapping protein-coding ab initio gene models",
+         "code" : "working-set",
+         "name" : "Working Gene Set",
+         "attrib_type_id" : "362"
+      },
+      {
+         "name" : "Filtered Gene Set v1",
+         "attrib_type_id" : "363",
+         "description" : "Working genes that are screened for TE content and orthology with sorghum and rice.",
+         "code" : "filtered-set"
+      },
+      {
+         "code" : "super-set",
+         "description" : "Set of all working gene set loci from both Builds 4a and 5a",
+         "attrib_type_id" : "364",
+         "name" : "Super Working Gene Set"
+      },
+      {
+         "description" : "Temporary (Monday, August 23, 2010)",
+         "code" : "projected4a2",
+         "name" : "Projected by alignment",
+         "attrib_type_id" : "365"
+      },
+      {
+         "description" : null,
+         "code" : "merged",
+         "name" : "Merged species",
+         "attrib_type_id" : "366"
+      },
+      {
+         "name" : "Rank in the karyotype",
+         "attrib_type_id" : "367",
+         "description" : "For a given seq_region, if it is part of the species karyotype, will indicate its rank",
+         "code" : "karyotype_rank"
+      },
+      {
+         "name" : "Alternate non coding gene count",
+         "attrib_type_id" : "368",
+         "description" : "Number of non coding genes on alternate sequences",
+         "code" : "noncoding_acnt"
+      },
+      {
+         "name" : "Coding genes",
+         "attrib_type_id" : "369",
+         "description" : "Number of protein coding genes on alternate sequences",
+         "code" : "coding_acnt"
+      },
+      {
+         "code" : "pseudogene_acnt",
+         "description" : "Number of pseudogenes on alternate sequences",
+         "attrib_type_id" : "370",
+         "name" : "Pseudogenes"
+      },
+      {
+         "attrib_type_id" : "371",
+         "name" : "Clone end",
+         "code" : "clone_end",
+         "description" : "Side of the contig on which a vector lies (enum:RIGHT, LEFT)."
+      },
+      {
+         "description" : "Scaffold that contains mutually ordered contigs.",
+         "code" : "contig_scaffold",
+         "name" : "Contig Scaffold",
+         "attrib_type_id" : "372"
+      },
+      {
+         "code" : "current_version",
+         "description" : "Identifies the most recent version of an accession.",
+         "attrib_type_id" : "373",
+         "name" : "Current Accession Version"
+      },
+      {
+         "attrib_type_id" : "374",
+         "name" : "Sequence Status",
+         "code" : "seq_status",
+         "description" : "Sequence status."
+      },
+      {
+         "attrib_type_id" : "375",
+         "name" : "Vector sequence",
+         "code" : "clone_vector",
+         "description" : "A clone-end vector associated with a contig (enum:SP6, T7)."
+      },
+      {
+         "code" : "creation_date",
+         "description" : "Creation date of annotation",
+         "attrib_type_id" : "376",
+         "name" : "Creation date"
+      },
+      {
+         "code" : "update_date",
+         "description" : "Last update date of annotation",
+         "attrib_type_id" : "377",
+         "name" : "Update date"
+      },
+      {
+         "code" : "seq_date",
+         "description" : "Sequence date",
+         "attrib_type_id" : "378",
+         "name" : "Sequence date"
+      },
+      {
+         "attrib_type_id" : "379",
+         "name" : "Contains stop codon",
+         "code" : "has_stop_codon",
+         "description" : "Translation attribute"
+      },
+      {
+         "description" : "Controlled vocabulary terms from Havana",
+         "code" : "havana_cv",
+         "name" : "Havana CV term",
+         "attrib_type_id" : "380"
+      },
+      {
+         "attrib_type_id" : "381",
+         "name" : "translated_processed_pseudogene",
+         "code" : "TlPPsCount",
+         "description" : "Number of Translated Processed Pseudogenes"
+      },
+      {
+         "attrib_type_id" : "382",
+         "name" : "No translations due to reference error",
+         "code" : "NoTransRefError",
+         "description" : "This gene is believed to include protein coding transcripts, but no transcript has a translation due to a reference assembly error making specifying the translation impossible."
+      },
+      {
+         "code" : "parent_exon_key",
+         "description" : "The exon key to identify a projected transcript's parent transcript.",
+         "attrib_type_id" : "383",
+         "name" : "parent_exon_key"
+      },
+      {
+         "code" : "parent_sid",
+         "description" : "The parent stable ID to identify a projected transcript's parent transcript. For internal statistics use only since this method does not work in all cases.",
+         "attrib_type_id" : "386",
+         "name" : "parent_sid"
+      },
+      {
+         "code" : "noncoding_acnt_s",
+         "description" : "Number of small non coding genes on alternate sequences",
+         "attrib_type_id" : "387",
+         "name" : "Small non coding genes"
+      },
+      {
+         "code" : "noncoding_acnt_m",
+         "description" : "Number of unclassified (miscellaneous) non coding genes on alternate sequences",
+         "attrib_type_id" : "388",
+         "name" : "Misc non coding genes"
+      },
+      {
+         "name" : "Small non coding genes",
+         "attrib_type_id" : "389",
+         "description" : "Number of small non coding genes",
+         "code" : "noncoding_cnt_s"
+      },
+      {
+         "name" : "Long non coding genes",
+         "attrib_type_id" : "390",
+         "description" : "Number of long non coding genes",
+         "code" : "noncoding_cnt_l"
+      },
+      {
+         "code" : "TlUPsCount",
+         "description" : "Number of Translated Unprocessed Pseudogenes",
+         "attrib_type_id" : "391",
+         "name" : "translated_unprocessed_pseudogene"
+      },
+      {
+         "description" : "Total Number of AFFYMETRIX features",
+         "code" : "AFFYMETRIXCount",
+         "name" : "AFFYMETRIX Count",
+         "attrib_type_id" : "393"
+      },
+      {
+         "attrib_type_id" : "394",
+         "name" : "RFLP Count",
+         "code" : "RFLPCount",
+         "description" : "Total Number of RFLP features"
+      },
+      {
+         "description" : "ID of associated database reference",
+         "code" : "xref_id",
+         "name" : "Xref ID",
+         "attrib_type_id" : "395"
+      },
+      {
+         "attrib_type_id" : "396",
+         "name" : "Vega chrom type",
+         "code" : "vega_chr_type",
+         "description" : "Type of chromosome - haplotype, other, etc"
+      },
+      {
+         "code" : "GeneNo_MRP_RNA",
+         "description" : "Number of MRP_RNA Genes",
+         "attrib_type_id" : "397",
+         "name" : "MRP_RNA Gene Count"
+      },
+      {
+         "description" : "Number of prediction genes generated by Genscan",
+         "code" : "genscan",
+         "name" : "Genscan gene predictions",
+         "attrib_type_id" : "398"
+      },
+      {
+         "code" : "gsc",
+         "description" : "Number of prediction genes generated by gsc",
+         "attrib_type_id" : "399",
+         "name" : "GSC gene prediction"
+      },
+      {
+         "attrib_type_id" : "400",
+         "name" : "Snap gene prediction",
+         "code" : "snap",
+         "description" : "Number of prediction genes generated by Snap"
+      },
+      {
+         "name" : "FGENESH gene prediction",
+         "attrib_type_id" : "401",
+         "description" : "Number of prediction genes generated by FGENESH",
+         "code" : "fgenesh"
+      },
+      {
+         "attrib_type_id" : "402",
+         "name" : "Genefinder gene prediction",
+         "code" : "genefinder",
+         "description" : "Number of prediction genes generated by Genefinder"
+      },
+      {
+         "code" : "transcript_cnt",
+         "description" : "Number of transcripts",
+         "attrib_type_id" : "403",
+         "name" : "Gene transcripts"
+      },
+      {
+         "attrib_type_id" : "404",
+         "name" : "Gene transcripts",
+         "code" : "transcript_acnt",
+         "description" : "Number of transcripts on the alternate sequences"
+      },
+      {
+         "description" : "Length of the primary assembly",
+         "code" : "ref_length",
+         "name" : "Golden Path Length",
+         "attrib_type_id" : "405"
+      },
+      {
+         "code" : "total_length",
+         "description" : "Total length of the assembly",
+         "attrib_type_id" : "406",
+         "name" : "Base Pairs"
+      },
+      {
+         "code" : "refseq_compare",
+         "description" : "This attribute can be applied to both gene and transcript. It is supposed to give an indication of whether the annotation in the ensembl database is matched by annotation that we have imported from refseq. At the gene level, the match is unlikely to be an exact match because all or some of the transcripts may differ. Also, the biotype e.g. coding potential may differ. therefore, matching is a bit fuzzy and is done primarily on genomic location and then also takes gene length and gene name into consideration.",
+         "attrib_type_id" : "407",
+         "name" : "refseq_compare"
+      },
+      {
+         "attrib_type_id" : "408",
+         "name" : "Readthrough coding genes",
+         "code" : "coding_rcnt",
+         "description" : "Number of readthrough coding genes"
+      },
+      {
+         "attrib_type_id" : "409",
+         "name" : "Readthrough coding genes",
+         "code" : "coding_racnt",
+         "description" : "Number of readthrough coding genes on alternate sequences"
+      },
+      {
+         "name" : "Readthrough long non coding genes",
+         "attrib_type_id" : "410",
+         "description" : "Number of readthrough long non coding genes on alternate sequences",
+         "code" : "noncoding_racnt_l"
+      },
+      {
+         "attrib_type_id" : "411",
+         "name" : "Readthrough small non coding genes",
+         "code" : "noncoding_racnt_s",
+         "description" : "Number of readthrough small non coding genes on alternate sequences"
+      },
+      {
+         "description" : "Number of readthrough small non coding genes",
+         "code" : "noncoding_rcnt_s",
+         "name" : "Readthrough small non coding genes",
+         "attrib_type_id" : "412"
+      },
+      {
+         "name" : "Readthrough long non coding genes",
+         "attrib_type_id" : "413",
+         "description" : "Number of readthrough long non coding genes",
+         "code" : "noncoding_rcnt_l"
+      },
+      {
+         "name" : "Readthrough pseudogenes",
+         "attrib_type_id" : "414",
+         "description" : "Number of readthrough pseudogenes",
+         "code" : "pseudogene_rcnt"
+      },
+      {
+         "code" : "pseudogene_racnt",
+         "description" : "Number of readthrough pseudogenes on alternate sequences",
+         "attrib_type_id" : "415",
+         "name" : "Readthrough pseudogenes"
+      },
+      {
+         "code" : "gencode_level",
+         "description" : "level 1 (verified loci), level 2 (manually annotated loci), level 3 (automatically annotated loci)",
+         "attrib_type_id" : "416",
+         "name" : "GENCODE annotation level"
+      },
+      {
+         "description" : "GENCODE Basic is a view provided by UCSC for users. It includes a subset of the GENCODE transcripts. In general, for protein coding genes it will show only the full length models (unless a protein coding genes has no full-length models, in which case other rules apply). For noncoding genes, it will also only show the full-length (mRNA start and end found) models (unless there are no full-length models, in which case other rules apply).",
+         "code" : "gencode_basic",
+         "name" : "GENCODE basic annotation",
+         "attrib_type_id" : "417"
+      },
+      {
+         "description" : "Total Number of structural variants",
+         "code" : "struct_var",
+         "name" : "Structural variants",
+         "attrib_type_id" : "418"
+      },
+      {
+         "attrib_type_id" : "419",
+         "name" : "GenBlastG gene predictions",
+         "code" : "genblast",
+         "description" : "Number of prediction genes generated by GenBlastG"
+      },
+      {
+         "code" : "syn_gene_pairs",
+         "description" : "Syntenic gene relationship from Gramene pipeline",
+         "attrib_type_id" : "420",
+         "name" : "Syntenic gene pairs"
+      },
+      {
+         "attrib_type_id" : "421",
+         "name" : "VectorBase gene predictions",
+         "code" : "vectorbase_adar",
+         "description" : "Number of prediction genes generated with MAKER, by VectorBase."
+      },
+      {
+         "name" : "tRNAscan-SE predictions",
+         "attrib_type_id" : "422",
+         "description" : "Number of predicted tRNA genes generated by tRNAscan-SE",
+         "code" : "trnascan"
+      },
+      {
+         "code" : "tgac_pred_supp7",
+         "description" : "Number of T. turgidum RNA-seq alignments from Krasileva et al.",
+         "attrib_type_id" : "423",
+         "name" : "T. turgidum RNA-seq alignments"
+      },
+      {
+         "name" : "T. aestivum RNA-seq alignments",
+         "attrib_type_id" : "424",
+         "description" : "Number of T. aestivum RNA-seq alignments from Krasileva et al.",
+         "code" : "tgac_pred_supp17"
+      },
+      {
+         "description" : "For polyploid genome, the genome component name the seq_region belongs to.",
+         "code" : "genome_component",
+         "name" : "Genome Component Name",
+         "attrib_type_id" : "425"
+      },
+      {
+         "description" : "RNA-seq transcripts from EchinoBase",
+         "code" : "transcript_whl",
+         "name" : "RNA-seq transcripts",
+         "attrib_type_id" : "426"
+      },
+      {
+         "description" : "Transcription Support Level (TSL) is a method to highlight the well-supported and poorly-supported transcript models for users. The method relies on the primary data that can support full-length transcript structure and data are provided by UCSC.  The following categories are assigned to each of the evaluated annotations. tsl1 - all splice junctions of the transcript are supported by at least one non-suspect mRNA. tsl2 - the best supporting mRNA is flagged as suspect or the support is from multiple ESTs. tsl3 - the only support is from a single EST. tsl4 - the best supporting EST is flagged as suspect. tsl5 - no single transcript supports the model structure. tslNA - the transcript was not analyzed for one of the following reasons: pseudogene annotation, including transcribed pseudogenes.Human leukocyte antigen (HLA) transcript. Immunoglobin gene transcript.  T-cell receptor transcript. Single-exon transcript (will be included in a future version)",
+         "code" : "TSL",
+         "name" : "Transcript Support Level",
+         "attrib_type_id" : "428"
+      },
+      {
+         "description" : "Protein coverage for this gene derived from geneTree in compara",
+         "code" : "protein_coverage",
+         "name" : "Protein Coverage",
+         "attrib_type_id" : "429"
+      },
+      {
+         "code" : "consensus_coverage",
+         "description" : "Consensus coverage for this gene derived from geneTree in compara",
+         "attrib_type_id" : "430",
+         "name" : "Consensus Coverage"
+      },
+      {
+         "description" : "Translation attribute",
+         "code" : "has_start_codon",
+         "name" : "Contains start codon",
+         "attrib_type_id" : "431"
+      },
+      {
+         "attrib_type_id" : "432",
+         "name" : "APPRIS principal isoform",
+         "code" : "appris_pi",
+         "description" : "Transcript expected to code for the main functional isoform based on a range of protein features. APPRIS is a system that deploys a range of computational methods to provide value to the annotations of the human genome. http://appris.bioinfo.cnio.es/ http://nar.oxfordjournals.org/content/41/D1/D110.long. Icon is {APPRIS} in green."
+      },
+      {
+         "code" : "appris_ci",
+         "description" : "APPRIS candidate principal isoform: Where there is no single 'appris_principal' variant the main functional isoform will be translated from one of the 'appris_candidate' genes. APPRIS is a system that deploys a range of computational methods to provide value to the annotations of the human genome. http://appris.bioinfo.cnio.es/ http://nar.oxfordjournals.org/content/41/D1/D110.long. Icon is {APPRIS} in amber.",
+         "attrib_type_id" : "433",
+         "name" : "APPRIS candidate principal isoform"
+      },
+      {
+         "name" : "APPRIS candidate principal isoform (longest coding sequence)",
+         "attrib_type_id" : "434",
+         "description" : "APPRIS candidate principal isoform (longest coding sequence): Where there is no single 'appris_principal' variant the main functional isoform will be translated from one of the 'appris_candidate' genes. Where there is no 'appris_candidate_ccd' or 'appris_candidate_longest_ccds' variant, the longest protein of the 'appris_candidate' variants is selected as the primary variant. APPRIS is a system that deploys a range of computational methods to provide value to the annotations of the human genome. http://appris.bioinfo.cnio.es/ http://nar.oxfordjournals.org/content/41/D1/D110.long. Icon is {APPRIS*} in amber.",
+         "code" : "appris_ci1"
+      },
+      {
+         "description" : "APPRIS candidate principal isoform (longest CCDS): Where there is no single 'appris_principal' variant the main functional isoform will be translated from one of the 'appris_candidate' genes. When there are several 'appris_candidate' transcripts in CCDS, APPRIS labels the longest CCDS. APPRIS is a system that deploys a range of computational methods to provide value to the annotations of the human genome. http://appris.bioinfo.cnio.es/ http://nar.oxfordjournals.org/content/41/D1/D110.long. Icon is {APPRIS**} in amber.",
+         "code" : "appris_ci2",
+         "name" : "APPRIS candidate principal isoform (longest CCDS)",
+         "attrib_type_id" : "435"
+      },
+      {
+         "attrib_type_id" : "436",
+         "name" : "APPRIS candidate principal isoform (CCDS)",
+         "code" : "appris_ci3",
+         "description" : "APPRIS candidate principal isoform (CCDS): Where there is no single 'appris_principal' variant the main functional isoform will be translated from one of the 'appris_candidate' genes. This 'appris_candidate' transcript is unique in being part of CCDS. APPRIS is a system that deploys a range of computational methods to provide value to the annotations of the human genome. http://appris.bioinfo.cnio.es/ http://nar.oxfordjournals.org/content/41/D1/D110.long. Icon is {APPRIS***} in amber."
+      },
+      {
+         "attrib_type_id" : "437",
+         "name" : "lncRNA_Count",
+         "code" : "lncRNACount",
+         "description" : "Number of lncRNAs"
+      },
+      {
+         "code" : "ncRNACount",
+         "description" : "Number of ncRNAs",
+         "attrib_type_id" : "438",
+         "name" : "ncRNA_Count"
+      },
+      {
+         "attrib_type_id" : "439",
+         "name" : "UnclassPT_Count",
+         "code" : "UnclassPTCount",
+         "description" : "Number of Unclassified Processed Transcripts"
+      },
+      {
+         "code" : "GeneNo_scaRNA",
+         "description" : "Number of scaRNA Genes",
+         "attrib_type_id" : "440",
+         "name" : "scaRNA Gene Count"
+      },
+      {
+         "code" : "GeneNo_sRNA",
+         "description" : "Number of sRNA Genes",
+         "attrib_type_id" : "441",
+         "name" : "sRNA Gene Count"
+      },
+      {
+         "attrib_type_id" : "442",
+         "name" : "CRISPR Gene Count",
+         "code" : "GeneNo_CRISPR",
+         "description" : "Number of CRISPR Genes"
+      },
+      {
+         "code" : "GeneNo_antitoxin",
+         "description" : "Number of antitoxin Genes",
+         "attrib_type_id" : "443",
+         "name" : "antitoxin Gene Count"
+      },
+      {
+         "attrib_type_id" : "444",
+         "name" : "Misc non coding genes",
+         "code" : "noncoding_cnt_m",
+         "description" : "Number of unclassified (miscellaneous) non coding genes"
+      },
+      {
+         "code" : "noncoding_rcnt_m",
+         "description" : "Number of readthrough unclassified (miscellaneous) non coding genes",
+         "attrib_type_id" : "445",
+         "name" : "Readthrough misc non coding genes"
+      },
+      {
+         "name" : "Readthrough misc non coding genes",
+         "attrib_type_id" : "446",
+         "description" : "Number of readthrough unclassified (miscellaneous) non coding genes on alternate sequences",
+         "code" : "noncoding_racnt_m"
+      },
+      {
+         "description" : "Number of long non coding genes on alternate sequences",
+         "code" : "noncoding_acnt_l",
+         "name" : "Long non coding genes",
+         "attrib_type_id" : "447"
+      },
+      {
+         "code" : "noncoding_racnt",
+         "description" : "Number of readthrough non coding genes on alternate sequences",
+         "attrib_type_id" : "448",
+         "name" : "Readthrough non coding genes"
+      },
+      {
+         "attrib_type_id" : "449",
+         "name" : "Readthrough non coding genes",
+         "code" : "noncoding_rcnt",
+         "description" : "Number of readthrough non coding genes"
+      },
+      {
+         "description" : "This is a transcript attribute that signifies an exact match between the underlying genomic sequence of the RefSeq transcript with the corresponding RefSeq mRNA sequence the model was built from (based on a match between the transcript stable id and an accession in the RefSeq mRNA file). An exact match occurs when the underlying genomic sequence of the model can be perfectly aligned to the mRNA sequence post polyA clipping.",
+         "code" : "rseq_mrna_match",
+         "name" : "RefSeq model genomic seq to mRNA match",
+         "attrib_type_id" : "450"
+      },
+      {
+         "code" : "rseq_mrna_mismatch",
+         "description" : "This is a transcript attribute that signifies a mismatch between the underlying genomic sequence of the RefSeq transcript with the corresponding RefSeq mRNA sequence the model was built from. A mismatch is deemed to have occurred if the underlying genomic sequence does not have a perfect alignment to the mRNA sequence post polyA clipping. It can also signify that no comparison was possible as the model stable id may not have had a corresponding entry in the RefSeq mRNA file (sometimes happens when accessions are retired or changed). When a mismatch occurs one or several of the following transcript attributes will also be present to provide more detail on the nature of the mismatch: rseq_5p_mismatch, rseq_cds_mismatch, rseq_3p_mismatch, rseq_nctran_mismatch, rseq_no_comparison",
+         "attrib_type_id" : "451",
+         "name" : "RefSeq model genomic seq to mRNA mismatch"
+      },
+      {
+         "code" : "rseq_5p_mismatch",
+         "description" : "This is a transcript attribute that signifies a mismatch between the underlying genomic sequence of the RefSeq transcript with the corresponding RefSeq mRNA sequence the model was built from. Specifically, there is a mismatch in the 5' UTR of the RefSeq model. Information about the mismatch can be found in the value field of the transcript attribute.",
+         "attrib_type_id" : "452",
+         "name" : "RefSeq model genomic seq (5' UTR) to mRNA mismatch"
+      },
+      {
+         "description" : "This is a transcript attribute that signifies a mismatch between the underlying genomic sequence of the RefSeq transcript with the corresponding RefSeq mRNA sequence the model was built from. Specifically, there is a mismatch in the CDS of the RefSeq model. Information about the mismatch can be found in the value field of the transcript attribute.",
+         "code" : "rseq_cds_mismatch",
+         "name" : "RefSeq model genomic seq (CDS) to mRNA mismatch",
+         "attrib_type_id" : "453"
+      },
+      {
+         "attrib_type_id" : "454",
+         "name" : "RefSeq model genomic seq (3' UTR) to mRNA mismatch",
+         "code" : "rseq_3p_mismatch",
+         "description" : "This is a transcript attribute that signifies a mismatch between the underlying genomic sequence of the RefSeq transcript with the corresponding RefSeq mRNA sequence the model was built from. Specifically, there is a mismatch in the 3' UTR of the RefSeq model. Information about the mismatch can be found in the value field of the transcript attribute."
+      },
+      {
+         "name" : "RefSeq model genomic seq (non-coding) to mRNA mismatch",
+         "attrib_type_id" : "455",
+         "description" : "This is a transcript attribute that signifies a mismatch between the underlying genomic sequence of the RefSeq transcript with the corresponding RefSeq mRNA sequence the model was built from. This is a comparison between the entire underlying genomic sequence of the RefSeq model to the mRNA in the case of RefSeq models that are non-coding. Information about the mismatch can be found in the value field of the transcript attribute.",
+         "code" : "rseq_nctran_mismatch"
+      },
+      {
+         "name" : "RefSeq model no comparison made to mRNA",
+         "attrib_type_id" : "456",
+         "description" : "This is a transcript attribute that signifies that no alignment was carried out between the underlying genomic sequence of RefSeq model and a corresponding RefSeq mRNA. The reason for this is generally that no corresponding, unversioned accession was found in the RefSeq mRNA file for the transcript stable id. This sometimes happens when accessions are retired or replaced. A second possibility is that the sequences were too long and problematic to align (though this is rare). The value field gives more information about the reason no comparison was possible.",
+         "code" : "rseq_no_comparison"
+      },
+      {
+         "name" : "RefSeq model to overlapping Ensembl model whole transcript match",
+         "attrib_type_id" : "457",
+         "description" : "This is a transcript attribute that signifies that for the RefSeq transcript there is an overlapping Ensembl model that is identical across the whole transcript. A whole transcript match is defined as follows: 1) In the case that both models are coding, the transcript, CDS and peptide sequences are all identical and the genomic coordinates of every exon match. 2) In the case that both transcripts are non-coding the transcript sequences and the genomic coordinates of every exon are identical. No comparison is made between a coding and a non-coding transcript. Useful related attributes are: rseq_ens_match_cds and rseq_ens_no_match.",
+         "code" : "rseq_ens_match_wt"
+      },
+      {
+         "description" : "This is a transcript attribute that signifies that for the RefSeq transcript there is an overlapping Ensembl model that is identical across the CDS region only. A CDS match is defined as follows: the CDS and peptide sequences are identical and the genomic coordinates of every translatable exon match. Useful related attributes are: rseq_ens_match_wt and rseq_ens_no_match.",
+         "code" : "rseq_ens_match_cds",
+         "name" : "RefSeq model to overlapping Ensembl model CDS match",
+         "attrib_type_id" : "458"
+      },
+      {
+         "code" : "rseq_ens_no_match",
+         "description" : "This is a transcript attribute that signifies that for the RefSeq transcript there is no overlapping Ensembl model that is identical across either the whole transcript or the CDS. This is caused by differences between the transcript, CDS or peptide sequences or between the exon genomic coordinates. Useful related attributes are: rseq_ens_match_wt and rseq_ens_match_cds.",
+         "attrib_type_id" : "459",
+         "name" : "RefSeq model to overlapping Ensembl model no match"
+      },
+      {
+         "code" : "otter_truncated",
+         "description" : "This feature extends beyond the slice, but has been trimmed. (For use in otter client-server communications.)",
+         "attrib_type_id" : "502",
+         "name" : "Otter truncated feature"
+      }
+   ],
+   "coord_system.chromosome" : {
+      "name" : "chromosome",
+      "attrib" : "default_version",
+      "version" : "Otter",
+      "rank" : "2",
+      "species_id" : "1",
+      "coord_system_id" : "2"
+   },
+   "coord_systems" : {
+     "chromosome" : {
+       "-version" : "Otter",
+       "-rank" : "2",
+       "-default" : "1",
+       "-sequence_level" : "0"
+     },
+     "clone" : {
+       "-version" : "Otter",
+       "-rank" : "3",
+       "-default" : "1",
+       "-sequence_level" : "0"
+     },
+     "contig" : {
+       "-version" : "Otter",
+       "-rank" : "4",
+       "-default" : "1",
+       "-sequence_level" : "0"
+     },
+     "dna_contig" : {
+       "-version" : "Otter",
+       "-rank" : "5",
+       "-default" : "1",
+       "-sequence_level" : "1"
+     }
+   }
+}

--- a/t/.OTC.get_meta_response.109.human_test.txt
+++ b/t/.OTC.get_meta_response.109.human_test.txt
@@ -1,0 +1,282 @@
+{
+   "schema_version" : {
+      "species_id" : null,
+      "values" : [
+         "83"
+      ]
+   },
+   "species.scientific_name" : {
+      "species_id" : "1",
+      "values" : [
+         "Homo sapiens"
+      ]
+   },
+   "assembly.mapping" : {
+      "species_id" : "1",
+      "values" : [
+         "clone#contig",
+         "subregion#contig",
+         "chromosome:Otter#chromosome:NCBI36",
+         "chromosome:Otter#contig",
+         "chromosome:NCBI36#contig",
+         "chromosome:Otter#contig#clone",
+         "chromosome:NCBI36#contig#clone",
+         "chromosome:OtterArchive#contig",
+         "chromosome:OtterArchive#contig#clone",
+         "chromosome:GRCh37#contig",
+         "chromosome:GRCh37#contig#clone",
+         "chromosome:Otter#chromosome:GRCh37",
+         "chromosome:Otter#chromosome:OtterArchive"
+      ]
+   },
+   "schema_type" : {
+      "species_id" : null,
+      "values" : [
+         "core"
+      ]
+   },
+   "species.classification" : {
+      "species_id" : "1",
+      "values" : [
+         "sapiens",
+         "Homo",
+         "Hominidae",
+         "Catarrhini",
+         "Haplorrhini",
+         "Primates",
+         "Euarchontoglires",
+         "Eutheria",
+         "Mammalia",
+         "Euteleostomi",
+         "Vertebrata",
+         "Craniata",
+         "Chordata",
+         "Metazoa",
+         "Eukaryota"
+      ]
+   },
+   "patch" : {
+      "species_id" : null,
+      "values" : [
+         "patch_40_41_a.sql|analysis_description_displayable",
+         "patch_40_41_b.sql|info_type_enum",
+         "patch_40_41_c.sql|xref_priority",
+         "patch_40_41_d.sql|ditag_primary_key_type",
+         "patch_40_41_e.sql|schema_version",
+         "patch_40_41_f.sql|attrib_indices",
+         "patch_41_42_a.sql|remove_xref_priority",
+         "patch_41_42_c.sql|analysis_description_unique",
+         "patch_41_42_d.sql|schema_version",
+         "patch_41_42_e.sql|ditag_autoincrement",
+         "patch_41_42_f.sql|analysis_description_web_data",
+         "patch_41_42_g.sql|genebuild_version_format_change",
+         "patch_41_42_b.sql|unconventional_transcripts",
+         "patch_42_43_a.sql|unmapped_object.parent",
+         "patch_42_43_b.sql|unmapped_object_probe2transcript",
+         "patch_42_43_c.sql|info_type_probe_unmapped",
+         "patch_42_43_d.sql|unmapped_object_external_db_id",
+         "patch_42_43_e.sql|gene_archive.peptide_archive_id.index",
+         "patch_42_43_f.sql|schema_version",
+         "patch_43_44_a.sql|rationalise_key_columns",
+         "patch_43_44_b.sql|optimise_ditag_tables",
+         "patch_43_44_c.sql|external_db_type",
+         "patch_43_44_d.sql|translation_stable_id_unique",
+         "patch_43_44_e.sql|schema_version",
+         "patch_43_44_f.sql|external_db_type_syn",
+         "patch_44_45_a.sql|schema_version",
+         "patch_44_45_b.sql|marker_index",
+         "patch_44_45_c.sql|db_release_not_null",
+         "patch_45_46_a.sql|schema_version",
+         "patch_45_46_b.sql|go_xref.source_xref_id",
+         "patch_45_46_c.sql|unmapped_object.external_db_id",
+         "patch_45_46_d.sql|meta_unique_key",
+         "patch_45_46_e.sql|external_db_new_cols",
+         "patch_45_46_f.sql|stable_id_event.uni_idx",
+         "patch_45_46_g.sql|object_xref_linkage_annotation",
+         "patch_46_47_a.sql|schema_version",
+         "patch_46_47_b.sql|new_align_columns",
+         "patch_46_47_c.sql|extend_db_release",
+         "patch_47_48_a.sql|schema_version",
+         "patch_48_49_a.sql|schema_version",
+         "patch_48_49_b.sql|new_canonical_transcript_column",
+         "patch_48_49_c.sql|regulatory_support_removal",
+         "patch_48_49_d.sql|new_info_type_enum",
+         "patch_48_49_e.sql|ensembl_object_type_not_null",
+         "patch_49_50_a.sql|schema_version",
+         "patch_49_50_b.sql|coord_system_version_default",
+         "patch_49_50_c.sql|canonical_transcript",
+         "patch_49_50_d.sql|seq_region_indices",
+         "patch_49_50_e.sql|mapping_seq_region",
+         "patch_50_51_a.sql|schema_version",
+         "patch_50_51_b.sql|protein_feature_hit_name",
+         "patch_50_51_c.sql|meta_coord_index",
+         "patch_50_51_d.sql|multispecies",
+         "patch_50_51_e.sql|feature_external_data",
+         "patch_50_51_f.sql|meta_species_id_values",
+         "patch_50_51_g.sql|protein_feature_score",
+         "patch_50_51_h.sql|external_db_db_name",
+         "patch_50_51_i.sql|meta_value_binary",
+         "patch_51_52_a.sql|schema_version",
+         "patch_51_52_b.sql|widen_columns",
+         "patch_51_52_c.sql|pair_dna_align_feature_id",
+         "patch_51_52_d.sql|external_db_description",
+         "patch_52_53_a.sql|schema_version",
+         "patch_52_53_b.sql|external_db_type_enum",
+         "patch_52_53_d.sql|drop_go_xref_index",
+         "patch_52_53_c.sql|identity_xref_rename",
+         "patch_53_54_a.sql|schema_version",
+         "patch_53_54_b.sql|widen_columns",
+         "patch_53_54_c.sql|identity_object_analysis_move",
+         "patch_54_55_a.sql|schema_version",
+         "patch_54_55_b.sql|add_go_xrefs_types",
+         "patch_54_55_c.sql|add_splicing_event_tables",
+         "patch_54_55_d.sql|add_dependent_xref_table",
+         "patch_54_55_e.sql|add_is_constitutive_column",
+         "patch_54_55_f.sql|coord_system.version_null",
+         "patch_54_55_g.sql|analysis_description.display_label_NOT_NULL",
+         "patch_54_55_h.sql|gene_archive.allow_for_NULLs",
+         "patch_55_56_a.sql|schema_version",
+         "patch_55_56_b.sql|add_index_names",
+         "patch_55_56_c.sql|drop_oligo_tables_and_xrefs",
+         "patch_55_56_d.sql|add_index_to_splicing_event_feature",
+         "patch_56_57_a.sql|schema_version",
+         "patch_56_57_b.sql|unmapped_object.typ_enum_tidy",
+         "patch_56_57_c.sql|external_db_type_enum",
+         "patch_56_57_d.sql|allow_meta_null",
+         "patch_56_57_e.sql|canonical_translations",
+         "patch_56_57_f.sql|simple_feature.display_label",
+         "patch_57_58_a.sql|schema_version",
+         "patch_58_59_a.sql|schema_version",
+         "patch_58_59_b.sql|assembly_exception_exc_type_enum",
+         "patch_58_59_c.sql|splicing_event_attrib_type_id",
+         "patch_58_59_d.sql|object_xref_extend_index",
+         "patch_58_59_e.sql|meta_schema_type",
+         "patch_59_60_a.sql|schema_version",
+         "patch_59_60_b.sql|rename_go_xref_table",
+         "patch_59_60_c.sql|QC_fixes",
+         "patch_60_61_a.sql|schema_version",
+         "patch_60_61_b.sql|create_seq_region_synonym_table",
+         "patch_60_61_c.sql|rejig_object_xref_indexes",
+         "patch_61_62_a.sql|schema_version",
+         "patch_61_62_b.sql|synonym_field_extension",
+         "patch_61_62_c.sql|db_name_db_release_idx",
+         "patch_61_62_d.sql|remove_display_label_linkable",
+         "patch_61_62_e.sql|seq_region_synonym_seq_region_idx",
+         "patch_62_63_a.sql|schema_version",
+         "patch_62_63_b.sql|indexing_changes",
+         "patch_62_63_c.sql|remove_dbprimary_acc_linkable",
+         "patch_63_64_a.sql|schema_version",
+         "patch_63_64_b.sql|add_operons",
+         "patch_63_64_c.sql|is_ref_added_to_alt_allele",
+         "patch_63_64_d.sql|linkage_type change in ontology_xref",
+         "patch_64_65_a.sql|schema_version",
+         "patch_64_65_b.sql|merge_stable_id_with_object",
+         "patch_64_65_c.sql|add_data_file",
+         "patch_64_65_d.sql|add_checksum_info_type",
+         "patch_65_66_a.sql|schema_version",
+         "patch_65_66_b.sql|fix_external_db_id",
+         "patch_65_66_c.sql|reorder_unmapped_obj_index",
+         "patch_65_66_d.sql|add_index_to_ontology_xref_table",
+         "patch_65_66_e.sql|fix_external_db_id_in_xref",
+         "patch_65_66_f.sql|drop_default_values",
+         "patch_66_67_a.sql|schema_version",
+         "patch_66_67_b.sql|drop_stable_id_views",
+         "patch_66_67_c.sql|adding_intron_supporting_evidence",
+         "patch_66_67_d.sql|adding_gene_transcript_annotated",
+         "patch_66_67_e.sql|index_canonical_transcript_id",
+         "patch_67_68_a.sql|schema_version",
+         "patch_67_68_b.sql|xref_uniqueness",
+         "patch_67_68_c.sql|altering_intron_supporting_evidence",
+         "patch_67_68_d.sql|add_is_splice_canonical_and_seq_index",
+         "patch_67_68_e.sql|fix_67_68_e_xref_index",
+         "patch_68_69_a.sql|schema_version",
+         "patch_69_70_a.sql|schema_version",
+         "patch_69_70_b.sql|add_mapping_set_history",
+         "patch_69_70_c.sql|column_datatype_consistency",
+         "patch_69_70_d.sql|data_file_id_auto_increment",
+         "patch_69_70_e.sql|protein_feature_hit_description",
+         "patch_70_71_a.sql|schema_version",
+         "patch_70_71_b.sql|mapping_set_index",
+         "patch_71_72_a.sql|schema_version",
+         "patch_71_72_b.sql|associated_xref",
+         "patch_72_73_a.sql|schema_version",
+         "patch_72_73_b.sql|alt_allele_type",
+         "patch_72_73_c.sql|add_object_type_marker",
+         "patch_73_74_a.sql|schema_version",
+         "patch_73_74_b.sql|remove_dnac",
+         "patch_73_74_c.sql|remove_unconventional_transcript_association",
+         "patch_73_74_d.sql|remove_qtl",
+         "patch_73_74_e.sql|remove_canonical_annotation",
+         "patch_73_74_f.sql|remove_pair_dna_align",
+         "patch_73_74_g.sql|add_transcript_idx_tise",
+         "patch_73_74_h.sql|alt_allele_unique_gene_idx",
+         "patch_74_75_a.sql|schema_version",
+         "patch_74_75_b.sql|transcript_source",
+         "patch_74_75_c.sql|add_genome_statistics",
+         "patch_74_75_d.sql|default_transcript_source",
+         "patch_74_75_e.sql|unique_attrib_key",
+         "patch_74_75_f.sql|longer_code",
+         "patch_75_76_a.sql|schema_version",
+         "patch_75_76_b.sql|allow_null_karyotype",
+         "patch_75_76_c.sql|remove_alternative_splicing",
+         "patch_76_77_a.sql|schema_version",
+         "patch_77_78_a.sql|schema_version",
+         "patch_77_78_b.sql|source_column_increase",
+         "patch_77_78_c.sql|Change unmapped_reason_id from smallint to int",
+         "patch_78_79_a.sql|schema_version",
+         "patch_78_79_b.sql|bamcov support",
+         "patch_79_80_a.sql|schema_version",
+         "patch_79_80_b.sql|xref_dbprimary_acc_longer",
+         "patch_79_80_c.sql|seq_region_synonym_longer",
+         "patch_79_80_d.sql|genome_statistics_value_longer",
+         "patch_80_81_a.sql|schema_version",
+         "patch_80_81_b.sql|xref_width",
+         "patch_81_82_a.sql|schema_version",
+         "patch_81_82_b.sql|xref_width",
+         "patch_81_82_c.sql|seq_synonym_key",
+         "patch_82_83_a.sql|schema_version"
+      ]
+   },
+   "species.common_name" : {
+      "species_id" : "1",
+      "values" : [
+         "human"
+      ]
+   },
+   "prefix.primary" : {
+      "values" : [
+         "OTT"
+      ],
+      "species_id" : "1"
+   },
+   "species.taxonomy_id" : {
+      "values" : [
+         "9606"
+      ],
+      "species_id" : "1"
+   },
+   "prefix.species" : {
+      "values" : [
+         "HUM"
+      ],
+      "species_id" : "1"
+   },
+   "species.display_name" : {
+      "species_id" : "1",
+      "values" : [
+         "Human"
+      ]
+   },
+   "species.production_name" : {
+      "species_id" : "1",
+      "values" : [
+         "homo_sapiens"
+      ]
+   },
+   "species.url" : {
+      "values" : [
+         "Homo_sapiens"
+      ],
+      "species_id" : "1"
+   }
+}

--- a/t/etc/test_regions/human_test:chr12-38:30351955-34820185.xml
+++ b/t/etc/test_regions/human_test:chr12-38:30351955-34820185.xml
@@ -13,6 +13,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>152951</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains a pseudogene similar to part of transmembrane and tetratricopeptide repeat containing 1 (TMTC1).</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -27,6 +29,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>186</fragment_offset>
        <clone_length>148610</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the IPO8 gene for importin 8.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -41,6 +45,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>171</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC023426.29.1.148610</id>
@@ -53,6 +59,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>71573</fragment_offset>
        <clone_length>148610</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the IPO8 gene for importin 8.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -67,6 +75,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>391</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC023426.29.1.148610</id>
@@ -79,6 +89,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>91641</fragment_offset>
        <clone_length>148610</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the IPO8 gene for importin 8.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -93,6 +105,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2006</fragment_offset>
        <clone_length>47302</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the IPO8 gene for importin 8.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -107,6 +121,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>141702</fragment_offset>
        <clone_length>199070</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the CAPRIN2 gene for caprin family member 2, a peptidylprolyl isomerase A (cyclophilin A) (PPIA) pseudogene, and two novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -121,6 +137,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>371</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC010198.8.1.199070</id>
@@ -133,6 +151,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>96919</fragment_offset>
        <clone_length>199070</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the CAPRIN2 gene for caprin family member 2, a peptidylprolyl isomerase A (cyclophilin A) (PPIA) pseudogene, and two novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -147,6 +167,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>264</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC010198.8.1.199070</id>
@@ -159,6 +181,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>199070</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the CAPRIN2 gene for caprin family member 2, a peptidylprolyl isomerase A (cyclophilin A) (PPIA) pseudogene, and two novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -173,6 +197,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>68935</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the TSPAN11 gene for tetraspanin 11.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -187,6 +213,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>214</fragment_offset>
        <clone_length>168986</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the TSPAN11 gene for tetraspanin 11, the DDX11 gene for DEAD/H (Asp-Glu-Ala-Asp/His) box polypeptide 11, the 3&apos; end of an ovostatin (OVOS) pseudogene, and three novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -201,6 +229,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>309</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC008013.8.1.168986</id>
@@ -213,6 +243,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>4112</fragment_offset>
        <clone_length>168986</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the TSPAN11 gene for tetraspanin 11, the DDX11 gene for DEAD/H (Asp-Glu-Ala-Asp/His) box polypeptide 11, the 3&apos; end of an ovostatin (OVOS) pseudogene, and three novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -227,6 +259,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>362</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC008013.8.1.168986</id>
@@ -239,6 +273,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>54271</fragment_offset>
        <clone_length>168986</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the TSPAN11 gene for tetraspanin 11, the DDX11 gene for DEAD/H (Asp-Glu-Ala-Asp/His) box polypeptide 11, the 3&apos; end of an ovostatin (OVOS) pseudogene, and three novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -253,6 +289,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>392</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC008013.8.1.168986</id>
@@ -265,6 +303,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>67306</fragment_offset>
        <clone_length>168986</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the TSPAN11 gene for tetraspanin 11, the DDX11 gene for DEAD/H (Asp-Glu-Ala-Asp/His) box polypeptide 11, the 3&apos; end of an ovostatin (OVOS) pseudogene, and three novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -279,6 +319,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>3888</fragment_offset>
        <clone_length>24091</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains part of an ovostatin (OVOS) pseudogene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -293,6 +335,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>205952</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of an ovostatin (OVOS) pseudogene, a ribosomal protein L13a (RPL13A) pseudogene, the FAM60A gene for family with sequence similarity 60, member A; and a solute carrier family 25, member 13 (citrin) (SLC25A13) pseudogene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -307,6 +351,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>106277</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains 3&apos; end of the DENND5B gene for DENN/MADD domain containing 5B and a novel gene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -321,6 +367,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2016</fragment_offset>
        <clone_length>178217</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the DENND5B gene for DENN/MADD domain containing 5B, a TAF10 RNA polymerase II, TATA box binding protein (TBP)-associated factor, 30kDa (TAF10) pseudogene, a mitochondrial ribosomal protein L30 (MRPL30) pseudogene, an ankyrin repeat domain 49 (ANKRD49) pseudogene, a ribosomal protein L31 (RPL31) pseudogene, an AK4P3 adenylate kinase 4 pseudogene 3 and a novel gene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -335,6 +383,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>29789</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the C12orf72 gene for chromosome 12 open reading frame 72.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -349,6 +399,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2113</fragment_offset>
        <clone_length>122351</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the C12orf72 gene for chromosome 12 open reading frame 72, the AMN1 gene for antagonist of mitotic exit network 1 homolog (S. cerevisiae), a stathmin 1 (STMN1) pseudogene, a dpy-30 homolog (C. elegans) (DPY30) pseudogene and an interferon induced transmembrane protein 3 (1-8U) (IFITM3) pseudogene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -363,6 +415,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2053</fragment_offset>
        <clone_length>186864</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the H3F3C gene for H3 histone, family 3C, a basic transcription factor 3-like 4 (BTF3L4) pseudogene, an Impact homolog (mouse) (IMPACT) pseudogene, a ribosomal protein, large, P2 (RPLP2) pseudogene, a ribosomal protein L12 (RPL12) pseudogene, a family with sequence similarity 98, member B (FAM98B) pseudogene, the 5&apos; end of the C12orf35 gene for chromosome 12 open reading frame 35 and a novel gene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -377,6 +431,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2005</fragment_offset>
        <clone_length>50743</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains 3&apos; end of the C12orf35 gene for chromosome 12 open reading frame 35 and a COX assembly mitochondrial protein homolog (S. cerevisiae) (CMC1) pseudogene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -391,6 +447,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2005</fragment_offset>
        <clone_length>124427</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains a gamma-aminobutyric acid (GABA) A receptor, pi (GABRP) pseudogene, the 5&apos; end of the BICD1 gene for bicaudal D homolog 1 (Drosophila) and a novel gene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -405,6 +463,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>190195</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains part of the BICD1 gene for bicaudal D homolog 1 (Drosophila) and a WW domain binding protein 2 (WBP2) pseudogene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -419,6 +479,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>37490</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains part of the BICD1 gene for bicaudal D homolog 1 (Drosophila).</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -433,6 +495,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>7000</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains part of the BICD1 gene for bicaudal D homolog 1 (Drosophila).</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -447,6 +511,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2000</fragment_offset>
        <clone_length>93342</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the BICD1 gene for bicaudal D homolog 1 (Drosophila) and the 5&apos; end of the FGD4 gene for FYVE, RhoGEF and PH domain containing 4.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -461,6 +527,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2005</fragment_offset>
        <clone_length>60429</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the FGD4 gene for FYVE, RhoGEF and PH domain containing 4.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -475,6 +543,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2004</fragment_offset>
        <clone_length>134628</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains part of the FGD4 gene for FYVE, RhoGEF and PH domain containing 4.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -489,6 +559,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2005</fragment_offset>
        <clone_length>98236</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the FGD4 gene for FYVE, RhoGEF and PH domain containing 4, the 5&apos; end of the DNM1L gene for dynamin 1-like, a chromosome 7 open reading frame 30 (C7orf30) pseudogene, a nucleosome assembly protein 1-like 1 (NAP1L1) pseudogene and part of the YARS2 gene for tyrosyl-tRNA synthetase 2, mitochondrial.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -503,6 +575,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>146167</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the DNM1L gene for dynamin 1-like, the YARS2 gene for tyrosyl-tRNA synthetase 2, mitochondrial, the 3&apos; end of the PKP2 gene for plakophilin 2 and a ribosomal protein L35a (RPL35A) pseudogene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -517,6 +591,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>159688</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the PKP2 gene for plakophilin 2, an argininosuccinate synthase 1 (ASS1) pseudogene and a novel gene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -531,6 +607,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>88874</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- no genes</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -545,6 +623,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2006</fragment_offset>
        <clone_length>162978</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- no genes</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -559,6 +639,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>383</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC021070.24.1.162978</id>
@@ -571,6 +653,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>64286</fragment_offset>
        <clone_length>162978</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- no genes</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -585,6 +669,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>146530</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the SYT10 gene for synaptotagmin X and a novel gene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -599,6 +685,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>86970</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the SYT10 gene for synaptotagmin X and a suppression of tumorigenicity 13 (colon carcinoma) (Hsp70 interacting protein) (ST13) pseudogene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -613,6 +701,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>50983</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- no genes</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -627,6 +717,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2043</fragment_offset>
        <clone_length>178905</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- no genes</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -641,6 +733,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>186000</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- no genes</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -655,6 +749,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>90455</fragment_offset>
        <clone_length>101027</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- no genes</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -669,6 +765,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>208</fragment_offset>
        <clone_length>176600</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the ALG10 gene for asparagine-linked glycosylation 10, alpha-1,2-glucosyltransferase homolog (S. pombe) and two novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -683,6 +781,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>134878</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains a family with sequence similarity 41, member A, Y-linked 1 (FAM41AY1) pseudogene, tubulin, beta 8 class VIII pseudogene 4 TUBB8P4, a double homeobox, 4-like (DUX4) pseudogene and two novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -697,6 +797,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>174598</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains a TAF9 RNA polymerase II, TATA box binding protein (TBP)-associated factor, 32kDa (TAF9) pseudogene.</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -711,6 +813,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2012</fragment_offset>
        <clone_length>131101</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- no genes</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -725,6 +829,8 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>156422</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- no genes</remark>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
@@ -739,6 +845,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>22467</fragment_offset>
        <clone_length>38114</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>ABBA01016732.1.1.3474</id>
@@ -751,6 +859,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>3474</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <feature_set>
        <feature>

--- a/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
+++ b/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
@@ -5,8 +5,6 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -15,14 +13,14 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>2001</fragment_offset>
        <clone_length>129814</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the SNTG2 gene for syntrophin gamma 2, a novel gene and a CpG island.</remark>
        <keyword>SNTG2</keyword>
      </sequence_fragment>
      <sequence_fragment>
        <id>KF456632.1.1.330</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>KF456632</accession>
        <version>1</version>
        <clone_name>KF456632.1</clone_name>
@@ -31,12 +29,12 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>330</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -45,14 +43,14 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>23590</fragment_offset>
        <clone_length>129814</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the SNTG2 gene for syntrophin gamma 2, a novel gene and a CpG island.</remark>
        <keyword>SNTG2</keyword>
      </sequence_fragment>
      <sequence_fragment>
        <id>KF456630.1.1.371</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>KF456630</accession>
        <version>1</version>
        <clone_name>KF456630.1</clone_name>
@@ -61,12 +59,12 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>371</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -75,14 +73,14 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>38288</fragment_offset>
        <clone_length>129814</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the SNTG2 gene for syntrophin gamma 2, a novel gene and a CpG island.</remark>
        <keyword>SNTG2</keyword>
      </sequence_fragment>
      <sequence_fragment>
        <id>KF456628.1.1.381</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>KF456628</accession>
        <version>1</version>
        <clone_name>KF456628.1</clone_name>
@@ -91,12 +89,12 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>381</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -105,14 +103,14 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>84474</fragment_offset>
        <clone_length>129814</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 5&apos; end of the SNTG2 gene for syntrophin gamma 2, a novel gene and a CpG island.</remark>
        <keyword>SNTG2</keyword>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC114808.4.1.176316</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>AC114808</accession>
        <version>4</version>
        <clone_name>RP11-1268F2</clone_name>
@@ -121,14 +119,14 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>176316</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains part of the SNTG2 gene for syntrophin gamma 2, two novel genes and a CpG island.</remark>
        <keyword>SNTG2</keyword>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC225604.3.1.72250</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>AC225604</accession>
        <version>3</version>
        <clone_name>CH16-67O12</clone_name>
@@ -137,12 +135,12 @@
        <fragment_ori>-1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>72250</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC140476.2.1.172117</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>AC140476</accession>
        <version>2</version>
        <clone_name>RP11-1294H20</clone_name>
@@ -151,14 +149,14 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1433</fragment_offset>
        <clone_length>172117</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains part of the SNTG2 gene for syntrophin gamma 2.</remark>
        <keyword>SNTG2</keyword>
      </sequence_fragment>
      <sequence_fragment>
        <id>AC108462.5.1.161648</id>
        <chromosome>2</chromosome>
-       <coord_system_name>chromosome</coord_system_name>
-       <coord_system_version>Otter</coord_system_version>
        <accession>AC108462</accession>
        <version>5</version>
        <clone_name>RP13-542C4</clone_name>
@@ -167,6 +165,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>1</fragment_offset>
        <clone_length>161648</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains the 3&apos; end of the SNTG2 gene for syntrophin gamma 2, the 5&apos; end of the TPO gene for thyroid peroxidase and a novel gene.</remark>
        <keyword>SNTG2</keyword>
        <keyword>TPO</keyword>

--- a/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
+++ b/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
@@ -5,6 +5,8 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -19,6 +21,8 @@
      <sequence_fragment>
        <id>KF456632.1.1.330</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>KF456632</accession>
        <version>1</version>
        <clone_name>KF456632.1</clone_name>
@@ -31,6 +35,8 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -45,6 +51,8 @@
      <sequence_fragment>
        <id>KF456630.1.1.371</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>KF456630</accession>
        <version>1</version>
        <clone_name>KF456630.1</clone_name>
@@ -57,6 +65,8 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -71,6 +81,8 @@
      <sequence_fragment>
        <id>KF456628.1.1.381</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>KF456628</accession>
        <version>1</version>
        <clone_name>KF456628.1</clone_name>
@@ -83,6 +95,8 @@
      <sequence_fragment>
        <id>AC116614.6.1.129814</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC116614</accession>
        <version>6</version>
        <clone_name>CTD-2029L3</clone_name>
@@ -97,6 +111,8 @@
      <sequence_fragment>
        <id>AC114808.4.1.176316</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC114808</accession>
        <version>4</version>
        <clone_name>RP11-1268F2</clone_name>
@@ -111,6 +127,8 @@
      <sequence_fragment>
        <id>AC225604.3.1.72250</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC225604</accession>
        <version>3</version>
        <clone_name>CH16-67O12</clone_name>
@@ -123,6 +141,8 @@
      <sequence_fragment>
        <id>AC140476.2.1.172117</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC140476</accession>
        <version>2</version>
        <clone_name>RP11-1294H20</clone_name>
@@ -137,6 +157,8 @@
      <sequence_fragment>
        <id>AC108462.5.1.161648</id>
        <chromosome>2</chromosome>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <accession>AC108462</accession>
        <version>5</version>
        <clone_name>RP13-542C4</clone_name>

--- a/t/etc/test_regions/human_test:chr6-38:2557766-2647766.xml
+++ b/t/etc/test_regions/human_test:chr6-38:2557766-2647766.xml
@@ -13,6 +13,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>89977</fragment_offset>
        <clone_length>120512</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>Annotation_remark- annotated</remark>
      </sequence_fragment>
      <sequence_fragment>
@@ -26,6 +28,8 @@
        <fragment_ori>1</fragment_ori>
        <fragment_offset>101</fragment_offset>
        <clone_length>107888</clone_length>
+       <coord_system_name>chromosome</coord_system_name>
+       <coord_system_version>Otter</coord_system_version>
        <remark>EMBL_dump_info.DE_line- Contains part of a gene for a novel protein similar to myosin light chain kinase and two novel genes.</remark>
        <remark>Annotation_remark- annotated</remark>
        <keyword>myosin</keyword>

--- a/t/lib/Test/Bio/Vega.pm
+++ b/t/lib/Test/Bio/Vega.pm
@@ -38,10 +38,23 @@ sub setup : Tests(setup) {
 # Overrideable - default is a plain in-memory one
 #
 sub get_coord_system_factory {
+    my ($test) = @_;
     require Bio::Vega::CoordSystemFactory;
-    return Bio::Vega::CoordSystemFactory->new;
+    return Bio::Vega::CoordSystemFactory->new(%{$test->get_coord_system_factory_override_spec});
 }
 
+sub get_coord_system_factory_override_spec {
+  my ($test) = @_;
+
+  return {
+    override_spec => {
+      chromosome => { '-version' => 'Otter', '-rank' => 2, '-default' => 1,                         },
+      clone      => {                        '-rank' => 4, '-default' => 1,                         },
+      contig     => {                        '-rank' => 5, '-default' => 1,                         },
+      dna_contig => { '-version' => 'Otter', '-rank' => 6, '-default' => 1, '-sequence_level' => 1, },
+    }
+  }
+}
 sub get_bio_vega_transform_xmltoregion {
     require Bio::Vega::Transform::XMLToRegion;
     return Bio::Vega::Transform::XMLToRegion->new;

--- a/t/lib/Test/Bio/Vega/CoordSystemFactory.pm
+++ b/t/lib/Test/Bio/Vega/CoordSystemFactory.pm
@@ -30,6 +30,15 @@ sub startup {
 
 sub build_attributes { return };
 
+sub our_args {
+    return [override_spec => {
+      chromosome => { '-version' => 'Otter', '-rank' => 2, '-default' => 1,                         },
+      clone      => {                        '-rank' => 4, '-default' => 1,                         },
+      contig     => {                        '-rank' => 5, '-default' => 1,                         },
+      dna_contig => { '-version' => 'Otter', '-rank' => 6, '-default' => 1, '-sequence_level' => 1, },
+    }];
+}
+
 sub coord_systems : Tests {
     my $test = shift;
 
@@ -50,7 +59,12 @@ sub coord_systems : Tests {
 sub override_spec : Tests {
     my $test = shift;
 
-    my $override_spec = { 'chromosome' => { '-dbid' => 2, '-version' => 'Test', '-rank' => 2, '-default' => 1, } };
+    my $override_spec = { 
+       'chromosome' => { '-version' => 'Test',  '-rank' => 2, '-default' => 1, '-dbid' => 2,           },
+       'clone'      => {                        '-rank' => 4, '-default' => 1,                         },
+       'contig'     => {                        '-rank' => 5, '-default' => 1,                         },
+       'dna_contig' => { '-version' => 'Otter', '-rank' => 6, '-default' => 1, '-sequence_level' => 1, }, 
+    };
 
     my $std_factory = $test->our_object;
     my $ovr_factory = $test->class->new( override_spec => $override_spec );
@@ -78,7 +92,7 @@ sub override_spec : Tests {
 sub dba_0_not_stored_yet : Tests {
     my $test = shift;
 
-    my $dba_factory = $test->class->new( dba => $test->dba );
+    my $dba_factory = $test->class->new( dba => $test->dba, @{$test->our_args} );
     foreach my $name ($dba_factory->known) {
         my $cs = $dba_factory->coord_system($name);
         ok not(defined($cs)), "$name: not defined";
@@ -90,8 +104,7 @@ sub dba_1_create_in_db : Tests {
     my $test = shift;
 
     my $dba = $test->dba;
-    my $dba_factory = $test->class->new( dba => $dba, create_in_db => 1 );
-
+    my $dba_factory = $test->class->new( dba => $dba, create_in_db => 1, @{$test->our_args});
     can_ok $dba_factory, 'instantiate_all';
     $dba_factory->instantiate_all;
 
@@ -110,7 +123,7 @@ sub dba_2_already_in_db : Tests {
     my $test = shift;
 
     my $dba = $test->dba;
-    my $dba_factory = $test->class->new( dba => $dba );
+    my $dba_factory = $test->class->new( dba => $dba, @{$test->our_args});
     foreach my $name ($dba_factory->known) {
         subtest $name => sub {
             my $cs = $dba_factory->coord_system($name);
@@ -119,18 +132,6 @@ sub dba_2_already_in_db : Tests {
             _note_cs($cs);
         };
     }
-    return;
-}
-
-sub assembly_mappings : Tests(2) {
-    my $test = shift;
-    my $factory = $test->our_object;
-
-    can_ok $factory, 'assembly_mappings';
-    my @mappings = $factory->assembly_mappings;
-    ok scalar(@mappings), '... and returns some mappings';
-    note 'n(assembly_mappings) = ', scalar(@mappings);
-
     return;
 }
 


### PR DESCRIPTION
First set of changes to the tests. Test for assembly_mapping has been removed as we do not use assembly_mappings method in modules/Bio/Vega/CoordSystemFactory.pm any more. 