### PR TITLE
Add status and is_known methods to Bio::Vega::Gene and Bio::Vega::Transcript

### DIFF
--- a/modules/Bio/Vega/Gene.pm
+++ b/modules/Bio/Vega/Gene.pm
@@ -382,7 +382,7 @@ sub status {
 }
 
 
-=head2 status
+=head2 is_known
 
  Arg [1]    : None
  Description: Return true if the gene is of status 'KNOWN'

--- a/modules/Bio/Vega/Gene.pm
+++ b/modules/Bio/Vega/Gene.pm
@@ -18,17 +18,6 @@ sub new {
   return $self;
 }
 
-#sub status {
-#  my ($self) = @_;
-
-#  return 'KNOWN';
-#}
-
-#sub is_known {
-#  my ($self) = @_;
-
-#  return 1;
-#}
 
 sub new_dissociated_copy {
     my ($self) = @_;
@@ -359,6 +348,16 @@ sub set_biotype_status_from_transcripts {
     return;
 }
 
+
+=head2 status
+
+ Arg [1]    : String (optional), status of the gene, KNOWN, PUTATIVE,...
+ Description: Return or set the status of the gene. The value will
+              be stored as an attribute.
+ Returntype : String
+ Exceptions : None
+
+=cut
 
 sub status {
   my ($self, $status) = @_;

--- a/modules/Bio/Vega/Gene.pm
+++ b/modules/Bio/Vega/Gene.pm
@@ -382,6 +382,22 @@ sub status {
 }
 
 
+=head2 status
+
+ Arg [1]    : None
+ Description: Return true if the gene is of status 'KNOWN'
+ Returntype : Boolean
+ Exceptions : None
+
+=cut
+
+sub is_known {
+  my ($self) = @_;
+
+  return ($self->status eq 'KNOWN' || $self->status eq 'KNOWN_BY_PROJECTION');
+}
+
+
 1;
 
 __END__

--- a/modules/Bio/Vega/Gene.pm
+++ b/modules/Bio/Vega/Gene.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Bio::EnsEMBL::Utils::Argument  qw ( rearrange );
 use Bio::EnsEMBL::Utils::Exception qw ( throw warning );
+use Bio::EnsEMBL::Attribute;
 use Bio::Vega::Utils::Attribute    qw ( get_first_Attribute_value get_name_Attribute_value );
 use Bio::Vega::Utils::AttributesMixin;
 use base 'Bio::EnsEMBL::Gene';
@@ -358,6 +359,28 @@ sub set_biotype_status_from_transcripts {
     return;
 }
 
+
+sub status {
+  my ($self, $status) = @_;
+
+  my $attributes = $self->get_all_Attributes('status');
+  if ($status) {
+    $self->{status} = $status;
+    if (@$attributes) {
+      $attributes->[0]->value($status);
+    }
+    else {
+      $self->add_Attributes(Bio::EnsEMBL::Attribute->new(-code => 'status', -value => $status));
+    }
+  }
+  elsif (!$self->{status} and @$attributes) {
+    if (@$attributes > 1) {
+      warning('You have multiple status attributes, using the first one '.$attributes->[0]);
+    }
+    $self->{status} = $attributes->[0]->value;
+  }
+  return $self->{status};
+}
 
 
 1;

--- a/modules/Bio/Vega/Transcript.pm
+++ b/modules/Bio/Vega/Transcript.pm
@@ -317,6 +317,22 @@ sub status {
 }
 
 
+=head2 status
+
+ Arg [1]    : None
+ Description: Return true if the transcript is of status 'KNOWN'
+ Returntype : Boolean
+ Exceptions : None
+
+=cut
+
+sub is_known {
+  my ($self) = @_;
+
+  return ($self->status eq 'KNOWN' || $self->status eq 'KNOWN_BY_PROJECTION');
+}
+
+
 1;
 
 __END__

--- a/modules/Bio/Vega/Transcript.pm
+++ b/modules/Bio/Vega/Transcript.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Bio::EnsEMBL::Utils::Argument qw ( rearrange );
 use Bio::EnsEMBL::Utils::Exception qw(throw warning);
+use Bio::EnsEMBL::Attribute;
 use Bio::Vega::Utils::AttributesMixin;
 use Bio::Vega::Evidence;
 use Bio::Vega::Translation;
@@ -292,6 +293,28 @@ sub last_db_version {
         $self->{_last_db_version} = shift @args;
     }
     return $self->{_last_db_version};
+}
+
+sub status {
+  my ($self, $status) = @_;
+
+  my $attributes = $self->get_all_Attributes('status');
+  if ($status) {
+    $self->{status} = $status;
+    if (@$attributes) {
+      $attributes->[0]->value($status);
+    }
+    else {
+      $self->add_Attributes(Bio::EnsEMBL::Attribute->new(-code => 'status', -value => $status));
+    }
+  }
+  elsif (!$self->{status} and @$attributes) {
+    if (@$attributes > 1) {
+      warning('You have multiple status attributes, using the first one '.$attributes->[0]);
+    }
+    $self->{status} = $attributes->[0]->value;
+  }
+  return $self->{status};
 }
 
 

--- a/modules/Bio/Vega/Transcript.pm
+++ b/modules/Bio/Vega/Transcript.pm
@@ -26,18 +26,6 @@ sub new {
   return $self;
 }
 
-#sub status {
-#  my ($self) = @_;
-
-#  return 'KNOWN';
-#}
-
-#sub is_known {
-#  my ($self) = @_;
-
-#  return 1;
-#}
-
 sub new_dissociated_copy {
     my ($self) = @_;
 
@@ -294,6 +282,17 @@ sub last_db_version {
     }
     return $self->{_last_db_version};
 }
+
+
+=head2 status
+
+ Arg [1]    : String (optional), status of the transcript, KNOWN, PUTATIVE,...
+ Description: Return or set the status of the transcript. The value will
+              be stored as an attribute.
+ Returntype : String
+ Exceptions : None
+
+=cut
 
 sub status {
   my ($self, $status) = @_;

--- a/modules/Bio/Vega/Transcript.pm
+++ b/modules/Bio/Vega/Transcript.pm
@@ -317,7 +317,7 @@ sub status {
 }
 
 
-=head2 status
+=head2 is_known
 
  Arg [1]    : None
  Description: Return true if the transcript is of status 'KNOWN'


### PR DESCRIPTION
The status and is_known method have been removed from the Ensembl Core API around release 90. These methods are needed for Otter to work. They might be removed in the future with a change in the client and the server as the status might not be relevant anymore.

This PR replace PR #27 