### PR TITLE
Retrieve the coord system name and version

### DIFF
--- a/modules/Bio/Otter/Lace/SequenceSet.pm
+++ b/modules/Bio/Otter/Lace/SequenceSet.pm
@@ -196,10 +196,10 @@ sub selected_CloneSequences_parameters {
 sub selected_CloneSequences_as_Slice {
     my ($self, $client) = @_;
 
-    my ($dsname, $ssname, $chr_name, $chr_start, $chr_end) = $self->selected_CloneSequences_parameters;
+    my ($dsname, $ssname, $chr_name, $chr_start, $chr_end, $cs_name, $cs_version) = $self->selected_CloneSequences_parameters;
     return Bio::Otter::Lace::Slice->new(
       $client, $dsname, $ssname,
-      'chromosome', 'Otter',
+      $cs_name, $cs_version,
       $chr_name, $chr_start, $chr_end,
       );
 }


### PR DESCRIPTION
Remove the default chromosome and Otter so we use the coord system version and name from the object