### PR TITLE
Remove Perl directives from .travis.yml [feature/ensembl_friendly]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-language: "perl"
-
-perl:
-  - "5.22"
 os:
   - linux
 services: docker


### PR DESCRIPTION
We do not actually USE Perl here, all the testing happens inside a Docker container. Just get rid of it, at the very least it will save our builds some time and bandwidth.