### PR TITLE
Replace hardcoded stable ids prefix

### DIFF
--- a/modules/Bio/Vega/DBSQL/StableIdAdaptor.pm
+++ b/modules/Bio/Vega/DBSQL/StableIdAdaptor.pm
@@ -47,7 +47,7 @@ sub _fetch_new_by_type {
 
     my $meta_container = $self->db->get_MetaContainer;
     my $prefix =
-        ($meta_container->get_primary_prefix || 'OTT')
+        ($meta_container->get_primary_prefix || 'ENS')
       . ($meta_container->get_species_prefix || '')
       . $type_prefix;
 


### PR DESCRIPTION
Resolving issue https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-3036 , 
generally stableIds are obtained from meta table, the only place where it is hardcoded and needs replace - is here. 