### PR TITLE
Use flush_Transcripts method to correctly empty the _transcript_array

### DIFF
--- a/modules/Bio/Vega/Transform/FromHumAce.pm
+++ b/modules/Bio/Vega/Transform/FromHumAce.pm
@@ -337,7 +337,6 @@ sub update_Gene {
 
     # $old_transcripts is the arrayref associated with $old_gene and now @new_gene, so we empty it to prevent
     # the gene adaptor from storing or removing the transcripts.
-    @$old_transcripts = ();
     $old_gene->flush_Transcripts;
 
     $new_gene->slice($self->whole_slice) unless $new_gene->slice;


### PR DESCRIPTION
Since release/85 get_all_Transcripts returns an arrayref on the copy
of the array of transcripts array instead of the actual reference.
So when the code was deleting the old_gene using later version of the
code it was also deleting the transcripts. This was not intended.

This has been lightly tested