### PR TITLE
Use RepeatMask instead of RepeatMasker in regex

### DIFF
--- a/modules/Bio/Vega/Utils/EnsEMBL2GFF.pm
+++ b/modules/Bio/Vega/Utils/EnsEMBL2GFF.pm
@@ -559,7 +559,7 @@ my $_new_feature_id_sub = sub {
         my ($self, @args) = @_;
         my $gff = $self->SUPER::_gff_hash(@args);
 
-        if ($self->analysis->logic_name =~ /RepeatMasker/i) {
+        if ($self->analysis->logic_name =~ /RepeatMask/i) {
             my $class = $self->repeat_consensus->repeat_class;
 
             if ($class =~ /LINE/) {


### PR DESCRIPTION
In Ensembl, the repeat masker analysis is repeatmask_repbase or
repeatmask_* so the previous regex looking for RepeatMasker does
not work anymore

This is some code I had for some time, it should fix ENSCORESW-3208