### PR TITLE
Set strand to 1 if not defined in object

### DIFF
--- a/modules/Bio/Vega/Transform/RegionToXML.pm
+++ b/modules/Bio/Vega/Transform/RegionToXML.pm
@@ -428,9 +428,7 @@ sub generate_FeatureSet {
           throw "Cannot create Otter XML, feature end is absent: $feature";
       }
 
-      if ($feature->strand){
-          $f->attribvals($self->prettyprint('strand',$feature->strand || 1));
-      }
+      $f->attribvals($self->prettyprint('strand',$feature->strand || 1));
 
       if ($feature->score){
           $f->attribvals($self->prettyprint('score',$feature->score));


### PR DESCRIPTION
When the Otter XML is created, it wants strand to be set for every
object but some Ensembl objects do not have their strand set as the
strand does not matter in some case. So we just set it to 1 for
simplicity

It may not me useful for human and mouse but it is needed when working on new species