### PR TITLE
Object of source ensembl_havana to be seen as havana

### DIFF
--- a/modules/Bio/Vega/Transform/RegionToXML.pm
+++ b/modules/Bio/Vega/Transform/RegionToXML.pm
@@ -203,7 +203,7 @@ sub generate_Locus {
 
     my ($type) = biotype_status2method($gene->biotype, $gene->status);
     my $source = $gene->source;
-    if ($source ne 'havana') {
+    if ($source ne 'havana'and $source ne 'ensembl_havana') {
         $type = "$source:$type";
     }
     $g->attribvals($self->prettyprint('type',$type));


### PR DESCRIPTION
The merge process is keeping all Havana genes so a ensembl_havana
gene is like a havana gene. Thus we want the merge genes to be seen
as normal havana genes.

Without this patch most of the genes will not be visible with version 37