### PR TITLE
Add source to XML and modify the source based on the annotation

### DIFF
--- a/modules/Bio/Vega/Transform/RegionToXML.pm
+++ b/modules/Bio/Vega/Transform/RegionToXML.pm
@@ -203,10 +203,11 @@ sub generate_Locus {
 
     my ($type) = biotype_status2method($gene->biotype, $gene->status);
     my $source = $gene->source;
-    if ($source ne 'havana'and $source ne 'ensembl_havana') {
+    if ($source ne 'havana' and $source ne 'ensembl_havana') {
         $type = "$source:$type";
     }
     $g->attribvals($self->prettyprint('type',$type));
+    $g->attribvals($self->prettyprint('source',$source));
 
     $g->attribvals($self->prettyprint('known',$gene->is_known || 0));
     $g->attribvals($self->prettyprint('truncated',$gene->truncated_flag));
@@ -279,6 +280,12 @@ sub generate_Transcript {
   ##in future <transcript_class> tag will be replaced by trancript <biotype> and <status> tags
   ##<type> tag will be removed
   my ($class) = biotype_status2method($tran->biotype, $tran->status);
+  my $source = $tran->source;
+  $t->attribvals($self->prettyprint('source', $source));
+  if ($source ne 'havana' and $source ne 'ensembl_havana') {
+    $t->attribvals($self->prettyprint('type', "$source:$class"));
+  }
+
   $t->attribvals($self->prettyprint('transcript_class', $class));
 
   my $tran_name = _feature_name($tran);

--- a/modules/Bio/Vega/Transform/XMLToRegion.pm
+++ b/modules/Bio/Vega/Transform/XMLToRegion.pm
@@ -480,6 +480,9 @@ sub _build_Transcript {         ## no critic (Subroutines::ProhibitUnusedPrivate
         $transcript->biotype($biotype);
         $transcript->status($status);
     }
+    if (my $source = $data->{'source'}) {
+      $transcript->source($source);
+    }
 
     if ($data->{'author'}) {
         my $transcript_author = $self->_make_Author($data->{'author'}, $data->{'author_email'});
@@ -596,6 +599,9 @@ sub _build_Locus {              ## no critic (Subroutines::ProhibitUnusedPrivate
     my ($biotype, $status) = method2biotype_status($type);
     $status = 'KNOWN' if $data->{'known'};
 
+    if (my $gene_source = $data->{source}) {
+      $source = $gene_source;
+    }
     $gene->source($source);
     $gene->biotype($biotype);
     $gene->status($status);
@@ -607,7 +613,6 @@ sub _build_Locus {              ## no critic (Subroutines::ProhibitUnusedPrivate
 
     ##share exons among transcripts of this gene
     foreach my $tran (@$transcripts) {
-        $tran->source($source); # copy from $gene, we don't need them to differ
         $gene->add_Transcript($tran);
     }
     $gene->prune_Exons;
@@ -634,7 +639,7 @@ sub _build_Locus {              ## no critic (Subroutines::ProhibitUnusedPrivate
         $transcript->end(  $transcript->end   - $slice_offset);
 
         my $logic_name = $transcript->analysis->logic_name;
-        if ($self->analysis_from_transcript_class and $source ne 'havana' and $logic_name ne 'Otter') {
+        if ($self->analysis_from_transcript_class and $source ne 'havana' and $source ne 'ensembl_havana' and $logic_name ne 'Otter') {
             $logic_name = sprintf('%s:%s', $source, $logic_name);
         }
         if ($truncated) {

--- a/modules/Bio/Vega/Utils/EnsEMBL2GFF.pm
+++ b/modules/Bio/Vega/Utils/EnsEMBL2GFF.pm
@@ -73,8 +73,12 @@ my $_new_feature_id_sub = sub {
         my ($self) = @_;
 
         if ($self->analysis) {
-            return $self->analysis->gff_source
-                || $self->analysis->logic_name;
+          my $gff_source = $self->analysis->gff_source || $self->analysis->logic_name;
+          if ($gff_source eq 'ensembl_havana:Predicted') {
+              $gff_source = 'ensembl:Predicted';
+          }
+          $gff_source =~ s/ensembl_havana://;
+            return $gff_source;
         }
         else {
             return ref($self);

--- a/modules/MenuCanvasWindow/SessionWindow.pm
+++ b/modules/MenuCanvasWindow/SessionWindow.pm
@@ -2570,6 +2570,9 @@ sub _replace_SubSeq_sqlite {
         if ($prev_locus) {
             $from_HumAce->update_Gene($prev_locus, $prev_locus);
         }
+        if ($old_locus->gene_type_prefix eq 'ensembl') {
+          $new_locus->gene_type_prefix('ensembl_havana');
+        }
 
         if ($old_locus and $old_locus->ensembl_dbID) {
             my $locus_diffs = $self->_compare_loci($old_locus, $new_locus);
@@ -2603,6 +2606,10 @@ sub _replace_SubSeq_sqlite {
         $vega_dba->commit;
         $self->_mark_unsaved;
         $done_sqlite = 1;
+        if ($new_locus->gene_type_prefix eq 'ensembl_havana') {
+          $new_locus->gene_type_prefix('');
+        }
+
 
         $done_zmap = $self->_replace_in_zmap($new_subseq, $old_subseq, $old_subseq->ensembl_dbID);
     }
@@ -3440,7 +3447,16 @@ sub zircon_zmap_view_zoom_to_subseq_xml {
     my ($self, $subseq) = @_;
 
     my $xml = Hum::XmlWriter->new;
-    $xml->open_tag('featureset', { name => $subseq->GeneMethod->name });
+    my $feature_set_name = $subseq->GeneMethod->name;
+    if ($subseq->Locus->gene_type_prefix) {
+      if ($subseq->GeneMethod->name eq 'Predicted' and $subseq->Locus->gene_type_prefix eq 'ensembl_havana') {
+        $feature_set_name = 'ensembl:Predicted';
+      }
+      elsif ($subseq->Locus->gene_type_prefix ne 'havana' and $subseq->Locus->gene_type_prefix ne 'ensembl_havana') {
+        $feature_set_name = $subseq->Locus->gene_type_prefix.':'.$subseq->GeneMethod->name;
+      }
+    }
+    $xml->open_tag('featureset', { name => $feature_set_name });
     $subseq->zmap_xml_feature_tag($xml, $self->AceDatabase->offset);
     $xml->close_all_open_tags;
 

--- a/t/etc/test_regions/human_test:chr12-38:30351955-34820185.xml
+++ b/t/etc/test_regions/human_test:chr12-38:30351955-34820185.xml
@@ -2125,6 +2125,7 @@
        <description>pseudogene similar to part of  transmembrane and tetratricopeptide repeat containing 1 (TMTC1)</description>
        <name>RP11-776A13.2</name>
        <type>Unprocessed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>mpk</author>
@@ -2133,6 +2134,8 @@
          <stable_id>OTTHUMT00000403575</stable_id>
          <author>mpk</author>
          <author_email>mpk</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Unprocessed_pseudogene</type>
          <transcript_class>Unprocessed_pseudogene</transcript_class>
          <name>RP11-776A13.2-001</name>
          <evidence_set>
@@ -2174,6 +2177,7 @@
        <description>importin 8</description>
        <name>IPO8</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -2183,6 +2187,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- CCDS8719.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-396L8.1-001</name>
          <translation_start>30695647</translation_start>
@@ -2426,6 +2432,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- more than 3 (independent) mRNA/EST support for novel TSS</remark>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-396L8.1-002</name>
          <translation_start>30676919</translation_start>
@@ -2626,6 +2634,8 @@
          <author_email>gm5</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-396L8.1-010</name>
          <translation_start>30637149</translation_start>
@@ -2671,6 +2681,8 @@
          <remark>Annotation_remark- Lies within novel first coding intron, so allowing novel first exon rules for CDS</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-396L8.1-003</name>
          <translation_start>30677126</translation_start>
@@ -2739,6 +2751,8 @@
          <author_email>gm5</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Non_stop_decay</type>
          <transcript_class>Non_stop_decay</transcript_class>
          <name>RP11-396L8.1-011</name>
          <translation_start>30681817</translation_start>
@@ -2775,6 +2789,8 @@
          <author_email>gm5</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-396L8.1-009</name>
          <translation_start>30684437</translation_start>
@@ -2828,6 +2844,8 @@
          <remark>not organism-supported</remark>
          <remark>Annotation_remark- Found in Sus scrofa (pig)</remark>
          <remark>Annotation_remark- truncated 2nd exon leads to an ORF that is 35AA, consequently leading to NMD</remark>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-396L8.1-008</name>
          <translation_start>30695647</translation_start>
@@ -2888,6 +2906,8 @@
          <author_email>gm5</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-396L8.1-007</name>
          <translation_start>30688456</translation_start>
@@ -2925,6 +2945,8 @@
          <remark>Annotation_remark- internal ATG utilized</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-396L8.1-006</name>
          <translation_start>30684437</translation_start>
@@ -2969,6 +2991,8 @@
          <author_email>gm5</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-396L8.1-004</name>
          <translation_start>30695010</translation_start>
@@ -3012,6 +3036,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- novel ATG start leads to an ORF less than 35AA, therefore annotated as transcript</remark>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-396L8.1-005</name>
          <evidence_set>
@@ -3045,6 +3071,7 @@
        <description>caprin family member 2</description>
        <name>CAPRIN2</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -3056,6 +3083,8 @@
          <remark>Annotation_remark- elongated third exon causes frameshift that leads to a premature stop codon, that subsequently leads to NMD</remark>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-77I22.1-006</name>
          <translation_start>30753659</translation_start>
@@ -3196,6 +3225,8 @@
          <author_email>gm5</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>RP11-77I22.1-015</name>
          <translation_start>30735014</translation_start>
@@ -3347,6 +3378,8 @@
          <remark>Annotation_remark- in exon 13</remark>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-77I22.1-017</name>
          <translation_start>30751124</translation_start>
@@ -3495,6 +3528,8 @@
          <author_email>gm5</author_email>
          <remark>Annotation_remark- CCDS8720.1</remark>
          <remark>Annotation_remark- UniProtKB isoform 2</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-77I22.1-001</name>
          <translation_start>30753763</translation_start>
@@ -3654,6 +3689,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- absence of cassette exon causes a frameshift that leads to a premature stop codon, which subsequently leads to NMD</remark>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-77I22.1-003</name>
          <translation_start>30753763</translation_start>
@@ -3813,6 +3850,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- CCDS55816.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-77I22.1-004</name>
          <translation_start>30753763</translation_start>
@@ -3977,6 +4016,8 @@
          <author_email>jel</author_email>
          <remark>Annotation_remark- CCDS41766.1 update pending</remark>
          <remark>Annotation_remark- UniProtKB isoform 3</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-77I22.1-005</name>
          <translation_start>30753763</translation_start>
@@ -4143,6 +4184,8 @@
          <stable_id>OTTHUMT00000474539</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-77I22.1-018</name>
          <evidence_set>
@@ -4166,6 +4209,8 @@
          <stable_id>OTTHUMT00000474550</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-77I22.1-019</name>
          <evidence_set>
@@ -4235,6 +4280,8 @@
          <remark>Annotation_remark- splice donor site gga (first exon) shows good conservation in UCSC genome browser</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-77I22.1-002</name>
          <translation_start>30753520</translation_start>
@@ -4373,6 +4420,8 @@
          <stable_id>OTTHUMT00000403384</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-77I22.1-016</name>
          <evidence_set>
@@ -4413,6 +4462,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- Would be NMD, but the lack of a downstream splice acceptor site from the premature stop codon precludes this possibility; therefore annotated as a transcript</remark>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-77I22.1-014</name>
          <evidence_set>
@@ -4452,6 +4503,8 @@
          <stable_id>OTTHUMT00000403326</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-77I22.1-012</name>
          <evidence_set>
@@ -4509,6 +4562,8 @@
          <author_email>gm5</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-77I22.1-007</name>
          <translation_start>30735167</translation_start>
@@ -4569,6 +4624,8 @@
          <author_email>gm5</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-77I22.1-013</name>
          <translation_start>30735167</translation_start>
@@ -4627,6 +4684,8 @@
          <stable_id>OTTHUMT00000403329</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-77I22.1-011</name>
          <evidence_set>
@@ -4676,6 +4735,8 @@
          <author_email>gm5</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-77I22.1-010</name>
          <translation_start>30753520</translation_start>
@@ -4740,6 +4801,8 @@
          <author_email>gm5</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-77I22.1-008</name>
          <translation_start>30753520</translation_start>
@@ -4800,6 +4863,8 @@
          <author_email>gm5</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-77I22.1-009</name>
          <translation_start>30753520</translation_start>
@@ -4860,6 +4925,7 @@
        <description>novel transcript</description>
        <name>RP11-77I22.2</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>dm4</author>
@@ -4868,6 +4934,8 @@
          <stable_id>OTTHUMT00000403385</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-77I22.2-001</name>
          <evidence_set>
@@ -4901,6 +4969,7 @@
        <description>novel transcript</description>
        <name>RP11-77I22.3</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>ASB_lincRNA</remark>
@@ -4910,6 +4979,8 @@
          <stable_id>OTTHUMT00000403386</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-77I22.3-002</name>
          <evidence_set>
@@ -4941,6 +5012,8 @@
          <stable_id>OTTHUMT00000403387</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-77I22.3-001</name>
          <evidence_set>
@@ -4996,6 +5069,8 @@
          <stable_id>OTTHUMT00000403388</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-77I22.3-003</name>
          <evidence_set>
@@ -5029,6 +5104,7 @@
        <description>peptidylprolyl isomerase A (cyclophilin A) (PPIA) pseudogene</description>
        <name>RP11-77I22.4</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -5037,6 +5113,8 @@
          <stable_id>OTTHUMT00000403389</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-77I22.4-001</name>
          <evidence_set>
@@ -5078,6 +5156,7 @@
        <description>tetraspanin 11</description>
        <name>TSPAN11</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -5086,6 +5165,8 @@
          <stable_id>OTTHUMT00000399885</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-551L14.3-003</name>
          <translation_start>30953992</translation_start>
@@ -5121,6 +5202,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- CCDS31765.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-551L14.3-001</name>
          <translation_start>30953992</translation_start>
@@ -5207,6 +5290,8 @@
          <stable_id>OTTHUMT00000399887</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-551L14.3-004</name>
          <translation_start>30963955</translation_start>
@@ -5282,6 +5367,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>alternative 5&apos; UTR</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-551L14.3-002</name>
          <translation_start>30953992</translation_start>
@@ -5430,6 +5517,7 @@
        <description>novel transcript, antisense to TSPAN11</description>
        <name>RP11-551L14.4</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>cas</author>
@@ -5438,6 +5526,8 @@
          <stable_id>OTTHUMT00000474551</stable_id>
          <author>cas</author>
          <author_email>cas</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-551L14.4-005</name>
          <evidence_set>
@@ -5463,6 +5553,8 @@
          <author_email>cas</author_email>
          <remark>454 RNA-Seq supported</remark>
          <remark>Annotation_remark- IH8XKNN01D9Q7R</remark>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-551L14.4-004</name>
          <exon_set>
@@ -5520,6 +5612,8 @@
          <stable_id>OTTHUMT00000399889</stable_id>
          <author>cas</author>
          <author_email>cas</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-551L14.4-001</name>
          <evidence_set>
@@ -5567,6 +5661,8 @@
          <stable_id>OTTHUMT00000399890</stable_id>
          <author>cas</author>
          <author_email>cas</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-551L14.4-003</name>
          <evidence_set>
@@ -5606,6 +5702,8 @@
          <stable_id>OTTHUMT00000399891</stable_id>
          <author>cas</author>
          <author_email>cas</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-551L14.4-002</name>
          <evidence_set>
@@ -5639,6 +5737,7 @@
        <description>novel transcript</description>
        <name>RP11-551L14.6</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>aeb</author>
@@ -5649,6 +5748,8 @@
          <author_email>aeb</author_email>
          <remark>QC splicing correct</remark>
          <remark>dotter confirmed</remark>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-551L14.6-001</name>
          <evidence_set>
@@ -5682,6 +5783,7 @@
        <description>antisense to DDX11</description>
        <name>RP11-551L14.5</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -5690,6 +5792,8 @@
          <stable_id>OTTHUMT00000399893</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-551L14.5-001</name>
          <evidence_set>
@@ -5729,6 +5833,8 @@
          <stable_id>OTTHUMT00000399894</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-551L14.5-002</name>
          <evidence_set>
@@ -5760,6 +5866,8 @@
          <stable_id>OTTHUMT00000474553</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-551L14.5-003</name>
          <evidence_set>
@@ -5793,6 +5901,7 @@
        <description>DEAD/H (Asp-Glu-Ala-Asp/His) box polypeptide 11</description>
        <name>DDX11</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>aeb</author>
@@ -5801,6 +5910,8 @@
          <stable_id>OTTHUMT00000399720</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Artifact</type>
          <transcript_class>Artifact</transcript_class>
          <name>RP11-551L14.2-004</name>
          <evidence_set>
@@ -5930,6 +6041,8 @@
          <author_email>gm5</author_email>
          <remark>Annotation_remark- CCDS41767.1</remark>
          <remark>Annotation_remark- UniProtKB isoform 2</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-551L14.2-001</name>
          <translation_start>31078394</translation_start>
@@ -6169,6 +6282,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- absence of cassette exon causes a frameshift that leads to a premature stop codon downstream</remark>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-551L14.2-005</name>
          <translation_start>31078394</translation_start>
@@ -6284,6 +6399,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- UniProtKB isoform 3</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-551L14.2-006</name>
          <translation_start>31078472</translation_start>
@@ -6524,6 +6641,8 @@
          <author_email>aeb</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>RP11-551L14.2-019</name>
          <translation_start>31078394</translation_start>
@@ -6609,6 +6728,8 @@
          <remark>QC splicing correct</remark>
          <remark>dotter confirmed</remark>
          <remark>Annotation_remark- presence of cassette exon causes a frameshift that causes a premature stop codon downstream</remark>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-551L14.2-002</name>
          <translation_start>31078394</translation_start>
@@ -6843,6 +6964,8 @@
          <stable_id>OTTHUMT00000399725</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-551L14.2-007</name>
          <translation_start>31078472</translation_start>
@@ -6943,6 +7066,8 @@
          <author_email>aeb</author_email>
          <remark>QC splicing correct</remark>
          <remark>dotter confirmed</remark>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-551L14.2-008</name>
          <translation_start>31078394</translation_start>
@@ -7137,6 +7262,8 @@
          <stable_id>OTTHUMT00000399727</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-009</name>
          <evidence_set>
@@ -7363,6 +7490,8 @@
          <remark>alternative 5&apos; UTR</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-551L14.2-016</name>
          <translation_start>31078472</translation_start>
@@ -7443,6 +7572,8 @@
          <author_email>gm5</author_email>
          <remark>Annotation_remark- UniProtKB isoform 1</remark>
          <remark>Annotation_remark- near NAGNAG splice site at exon 9</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-551L14.2-003</name>
          <translation_start>31078394</translation_start>
@@ -7682,6 +7813,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- UniProtKB isoform 4</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-551L14.2-010</name>
          <translation_start>31078394</translation_start>
@@ -7916,6 +8049,8 @@
          <stable_id>OTTHUMT00000399730</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-011</name>
          <evidence_set>
@@ -7987,6 +8122,8 @@
          <stable_id>OTTHUMT00000399800</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-551L14.2-017</name>
          <translation_start>31078394</translation_start>
@@ -8045,6 +8182,8 @@
          <stable_id>OTTHUMT00000399731</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Artifact</type>
          <transcript_class>Artifact</transcript_class>
          <name>RP11-551L14.2-012</name>
          <evidence_set>
@@ -8159,6 +8298,8 @@
          <remark>QC splicing correct</remark>
          <remark>dotter confirmed</remark>
          <remark>Annotation_remark- presence of cassette exon causes a frameshift in the CDS that consequently produces a premature stop codon downstream</remark>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-551L14.2-013</name>
          <translation_start>31078394</translation_start>
@@ -8252,6 +8393,8 @@
          <remark>downstream ATG</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-551L14.2-015</name>
          <translation_start>31078185</translation_start>
@@ -8316,6 +8459,8 @@
          <remark>Annotation_remark- missing exons causes frameshift that causes a premature stop codon. However, the lack of a downstream splice acceptor site, greater than 50bp from the premature stop, precludes the possibility of NMD, therefore annotated as transcript</remark>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-551L14.2-020</name>
          <translation_start>31078520</translation_start>
@@ -8370,6 +8515,8 @@
          <remark>dotter confirmed</remark>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-551L14.2-018</name>
          <translation_start>31083828</translation_start>
@@ -8436,6 +8583,8 @@
          <stable_id>OTTHUMT00000399805</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-021</name>
          <evidence_set>
@@ -8475,6 +8624,8 @@
          <stable_id>OTTHUMT00000399806</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-014</name>
          <evidence_set>
@@ -8534,6 +8685,8 @@
          <stable_id>OTTHUMT00000399807</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-551L14.2-022</name>
          <evidence_set>
@@ -8581,6 +8734,8 @@
          <stable_id>OTTHUMT00000399808</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-023</name>
          <evidence_set>
@@ -8660,6 +8815,8 @@
          <stable_id>OTTHUMT00000399809</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-551L14.2-025</name>
          <evidence_set>
@@ -8747,6 +8904,8 @@
          <stable_id>OTTHUMT00000399810</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-024</name>
          <evidence_set>
@@ -8802,6 +8961,8 @@
          <stable_id>OTTHUMT00000399817</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-026</name>
          <evidence_set>
@@ -8851,6 +9012,8 @@
          <author_email>aeb</author_email>
          <remark>QC splicing correct</remark>
          <remark>dotter confirmed</remark>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-028</name>
          <evidence_set>
@@ -8898,6 +9061,8 @@
          <stable_id>OTTHUMT00000399819</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-027</name>
          <evidence_set>
@@ -8929,6 +9094,8 @@
          <stable_id>OTTHUMT00000399834</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-032</name>
          <evidence_set>
@@ -8960,6 +9127,8 @@
          <stable_id>OTTHUMT00000399820</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-551L14.2-029</name>
          <evidence_set>
@@ -9001,6 +9170,8 @@
          <author_email>gm5</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-551L14.2-031</name>
          <translation_start>31102268</translation_start>
@@ -9063,6 +9234,8 @@
          <remark>dotter confirmed</remark>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>RP11-551L14.2-030</name>
          <translation_start>31102268</translation_start>
@@ -9131,6 +9304,7 @@
        <description>WAS protein family homolog 4 pseudogene</description>
        <name>RP11-551L14.7</name>
        <type>Unprocessed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>ib2</author>
@@ -9140,6 +9314,8 @@
          <author>ib2</author>
          <author_email>ib2</author_email>
          <remark>Annotation_remark- Contains exon structure similar to parental gene WASH4P which has been mistakenly called a pseudogene and actually a protein coding gene</remark>
+         <source>ensembl</source>
+         <type>ensembl:Unprocessed_pseudogene</type>
          <transcript_class>Unprocessed_pseudogene</transcript_class>
          <name>RP11-551L14.7-001</name>
          <evidence_set>
@@ -9205,6 +9381,7 @@
        <description>ovostatin (OVOS) pseudogene</description>
        <name>RP11-551L14.1</name>
        <type>Transcribed_unprocessed_pseudogene</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -9213,6 +9390,8 @@
          <stable_id>OTTHUMT00000400342</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-551L14.1-003</name>
          <evidence_set>
@@ -9292,6 +9471,8 @@
          <stable_id>OTTHUMT00000400343</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-551L14.1-002</name>
          <evidence_set>
@@ -9348,6 +9529,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- There is an introduced stop codon (c to g) in this haplotype that gives a Tyrosine in other individuals. There is also a c/t SNP here rs61917095</remark>
+         <source>ensembl</source>
+         <type>ensembl:Transcribed_unprocessed_pseudogene</type>
          <transcript_class>Transcribed_unprocessed_pseudogene</transcript_class>
          <name>RP11-551L14.1-001</name>
          <evidence_set>
@@ -9627,6 +9810,8 @@
          <stable_id>OTTHUMT00000400344</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-551L14.1-004</name>
          <evidence_set>
@@ -9692,6 +9877,7 @@
        <description>NADH dehydrogenase (ubiquinone) 1 alpha subcomplex, 4, 9kDa (NDUFA4) pseudogene</description>
        <name>RP11-627K11.5</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>clb</author>
@@ -9700,6 +9886,8 @@
          <stable_id>OTTHUMT00000469163</stable_id>
          <author>clb</author>
          <author_email>clb</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-627K11.5-001</name>
          <evidence_set>
@@ -9725,6 +9913,7 @@
        <description>ribosomal protein L13a (RPL13A) pseudogene</description>
        <name>RP11-627K11.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>jel</author>
@@ -9733,6 +9922,8 @@
          <stable_id>OTTHUMT00000349019</stable_id>
          <author>jel</author>
          <author_email>jel</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-627K11.1-001</name>
          <evidence_set>
@@ -9766,6 +9957,7 @@
        <description>melanoregulin (MREG) pseudogene</description>
        <name>RP11-627K11.4</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>ib2</author>
@@ -9774,6 +9966,8 @@
          <stable_id>OTTHUMT00000469134</stable_id>
          <author>ib2</author>
          <author_email>ib2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-627K11.4-001</name>
          <evidence_set>
@@ -9799,6 +9993,7 @@
        <description>novel transcript, overlapping 3&apos;UTR of FAM60A</description>
        <name>RP11-627K11.6</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -9808,6 +10003,8 @@
          <stable_id>OTTHUMT00000474559</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:3&apos;_overlapping_ncRNA</type>
          <transcript_class>3&apos;_overlapping_ncRNA</transcript_class>
          <name>RP11-627K11.6-001</name>
          <evidence_set>
@@ -9837,6 +10034,7 @@
        <description>family with sequence similarity 60, member A</description>
        <name>FAM60A</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -9846,6 +10044,8 @@
          <stable_id>OTTHUMT00000400345</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-627K11.2-003</name>
          <evidence_set>
@@ -9901,6 +10101,8 @@
          <stable_id>OTTHUMT00000400346</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-627K11.2-002</name>
          <translation_start>31287695</translation_start>
@@ -9944,6 +10146,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- CCDS8723.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-627K11.2-001</name>
          <translation_start>31298204</translation_start>
@@ -10019,6 +10223,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>alternative 5&apos; UTR</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-627K11.2-004</name>
          <translation_start>31298204</translation_start>
@@ -10088,6 +10294,8 @@
          <remark>Annotation_remark- presence of casette exon leads to a premature stop codon in the CDS, which consequently causes an NMD</remark>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-627K11.2-009</name>
          <translation_start>31298175</translation_start>
@@ -10154,6 +10362,8 @@
          <stable_id>OTTHUMT00000400350</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-627K11.2-007</name>
          <translation_start>31287695</translation_start>
@@ -10215,6 +10425,8 @@
          <remark>alternative 5&apos; UTR</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-627K11.2-006</name>
          <translation_start>31298204</translation_start>
@@ -10276,6 +10488,8 @@
          <remark>alternative 5&apos; UTR</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-627K11.2-008</name>
          <translation_start>31298204</translation_start>
@@ -10334,6 +10548,8 @@
          <stable_id>OTTHUMT00000400353</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-627K11.2-005</name>
          <evidence_set>
@@ -10367,6 +10583,7 @@
        <description>solute carrier family 25, member 13 (citrin) (SLC25A13) pseudogene</description>
        <name>RP11-627K11.3</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -10375,6 +10592,8 @@
          <stable_id>OTTHUMT00000400354</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-627K11.3-001</name>
          <evidence_set>
@@ -10416,6 +10635,7 @@
        <description>novel transcript, antisense to FAM60A</description>
        <name>RP11-627K11.7</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>mh19</author>
@@ -10424,6 +10644,8 @@
          <stable_id>OTTHUMT00000475045</stable_id>
          <author>mh19</author>
          <author_email>mh19</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-627K11.7-001</name>
          <evidence_set>
@@ -10461,6 +10683,7 @@
        <description>novel transcript</description>
        <name>RP11-771K4.1</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -10469,6 +10692,8 @@
          <stable_id>OTTHUMT00000402039</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-771K4.1-001</name>
          <evidence_set>
@@ -10502,6 +10727,7 @@
        <description>DENN/MADD domain containing 5B</description>
        <name>DENND5B</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -10512,6 +10738,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS44857.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-771K4.2-001</name>
          <translation_start>31590832</translation_start>
@@ -10750,6 +10978,8 @@
          <stable_id>OTTHUMT00000402041</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Artifact</type>
          <transcript_class>Artifact</transcript_class>
          <name>RP11-771K4.2-005</name>
          <evidence_set>
@@ -10797,6 +11027,8 @@
          <stable_id>OTTHUMT00000402042</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-771K4.2-003</name>
          <translation_start>31500558</translation_start>
@@ -11003,6 +11235,8 @@
          <stable_id>OTTHUMT00000402043</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-771K4.2-008</name>
          <evidence_set>
@@ -11034,6 +11268,8 @@
          <stable_id>OTTHUMT00000402044</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-771K4.2-002</name>
          <translation_start>31590832</translation_start>
@@ -11130,6 +11366,8 @@
          <author_email>th2</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>RP11-771K4.2-004</name>
          <translation_start>31495902</translation_start>
@@ -11184,6 +11422,8 @@
          <stable_id>OTTHUMT00000402046</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-771K4.2-007</name>
          <evidence_set>
@@ -11227,6 +11467,8 @@
          <stable_id>OTTHUMT00000402047</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-771K4.2-006</name>
          <translation_start>31590832</translation_start>
@@ -11279,6 +11521,7 @@
        <description>novel transcript, sense intronic to DENND5B</description>
        <name>RP11-771K4.3</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -11288,6 +11531,8 @@
          <stable_id>OTTHUMT00000474570</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP11-771K4.3-001</name>
          <evidence_set>
@@ -11313,6 +11558,7 @@
        <description>TAF10 RNA polymerase II, TATA box binding protein (TBP)-associated factor, 30kDa (TAF10) pseudogene</description>
        <name>RP11-820K3.3</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -11321,6 +11567,8 @@
          <stable_id>OTTHUMT00000402048</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-820K3.3-001</name>
          <evidence_set>
@@ -11346,6 +11594,7 @@
        <description>mitochondrial ribosomal protein L30 (MRPL30) pseudogene</description>
        <name>RP11-820K3.4</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -11354,6 +11603,8 @@
          <stable_id>OTTHUMT00000402049</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-820K3.4-001</name>
          <evidence_set>
@@ -11379,6 +11630,7 @@
        <description>ankyrin repeat domain 49 (ANKRD49) pseudogene</description>
        <name>RP11-820K3.2</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -11388,6 +11640,8 @@
          <stable_id>OTTHUMT00000402050</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-820K3.2-001</name>
          <evidence_set>
@@ -11417,6 +11671,7 @@
        <description>novel transcript</description>
        <name>RP11-820K3.5</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -11425,6 +11680,8 @@
          <stable_id>OTTHUMT00000402190</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-820K3.5-002</name>
          <evidence_set>
@@ -11464,6 +11721,8 @@
          <stable_id>OTTHUMT00000402191</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-820K3.5-001</name>
          <evidence_set>
@@ -11505,6 +11764,7 @@
        <description>ribosomal protein L31 (RPL31) pseudogene</description>
        <name>RP11-820K3.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>mms</author>
@@ -11513,6 +11773,8 @@
          <stable_id>OTTHUMT00000349051</stable_id>
          <author>mms</author>
          <author_email>mms</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-820K3.1-001</name>
          <evidence_set>
@@ -11550,6 +11812,7 @@
        <description>AK4P3 adenylate kinase 4 pseudogene 3</description>
        <name>RP11-820K3.6</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -11558,6 +11821,8 @@
          <stable_id>OTTHUMT00000402192</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-820K3.6-001</name>
          <evidence_set>
@@ -11591,6 +11856,7 @@
        <description>chromosome 12 open reading frame 72</description>
        <name>C12orf72</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -11600,6 +11866,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>alternative 5&apos; UTR</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-467L13.1-002</name>
          <translation_start>31661954</translation_start>
@@ -11651,6 +11919,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS8724.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-467L13.1-001</name>
          <translation_start>31661954</translation_start>
@@ -11706,6 +11976,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>alternative 5&apos; UTR</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-467L13.1-003</name>
          <translation_start>31661954</translation_start>
@@ -11765,6 +12037,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>alternative 5&apos; UTR</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-467L13.1-004</name>
          <translation_start>31661954</translation_start>
@@ -11818,6 +12092,8 @@
          <remark>alternative 5&apos; UTR</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-467L13.1-006</name>
          <translation_start>31661954</translation_start>
@@ -11852,6 +12128,8 @@
          <stable_id>OTTHUMT00000402198</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-467L13.1-005</name>
          <translation_start>31661954</translation_start>
@@ -11896,6 +12174,7 @@
        <description>antagonist of mitotic exit network 1 homolog (S. cerevisiae)</description>
        <name>AMN1</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -11906,6 +12185,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS44858.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-467L13.2-001</name>
          <translation_start>31729008</translation_start>
@@ -11990,6 +12271,8 @@
          <author_email>th2</author_email>
          <remark>alternative 5&apos; UTR</remark>
          <remark>upstream uORF</remark>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-467L13.2-005</name>
          <translation_start>31709409</translation_start>
@@ -12088,6 +12371,8 @@
          <stable_id>OTTHUMT00000402809</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-467L13.2-002</name>
          <translation_start>31689109</translation_start>
@@ -12159,6 +12444,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>upstream uORF</remark>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-467L13.2-004</name>
          <translation_start>31709409</translation_start>
@@ -12251,6 +12538,8 @@
          <author_email>th2</author_email>
          <remark>upstream uORF</remark>
          <remark>Annotation_remark- There is a uORF in the novel exons of this transcript but due to a lack of conservation I&apos;ve used this downstream ATG</remark>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-467L13.2-003</name>
          <translation_start>31689109</translation_start>
@@ -12336,6 +12625,8 @@
          <remark>alternative 5&apos; UTR</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-467L13.2-006</name>
          <translation_start>31709409</translation_start>
@@ -12412,6 +12703,8 @@
          <remark>not organism-supported</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-467L13.2-012</name>
          <translation_start>31709409</translation_start>
@@ -12464,6 +12757,8 @@
          <author_email>aeb</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-467L13.2-009</name>
          <translation_start>31709409</translation_start>
@@ -12516,6 +12811,8 @@
          <author_email>aeb</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-467L13.2-010</name>
          <translation_start>31709409</translation_start>
@@ -12590,6 +12887,8 @@
          <stable_id>OTTHUMT00000402994</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-467L13.2-011</name>
          <evidence_set>
@@ -12637,6 +12936,8 @@
          <stable_id>OTTHUMT00000402995</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-467L13.2-008</name>
          <evidence_set>
@@ -12676,6 +12977,8 @@
          <stable_id>OTTHUMT00000402813</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-467L13.2-007</name>
          <evidence_set>
@@ -12741,6 +13044,7 @@
        <description>stathmin 1 pseudogene 1</description>
        <name>STMN1P1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -12750,6 +13054,8 @@
          <stable_id>OTTHUMT00000473565</stable_id>
          <author>jel</author>
          <author_email>jel</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-467L13.6-001</name>
          <evidence_set>
@@ -12795,6 +13101,7 @@
        <description>novel transcript, antisense to AMN1</description>
        <name>RP11-467L13.7</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -12803,6 +13110,8 @@
          <stable_id>OTTHUMT00000474575</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-467L13.7-001</name>
          <evidence_set>
@@ -12844,6 +13153,7 @@
        <description>dpy-30 homolog (C. elegans) (DPY30) pseudogene</description>
        <name>RP11-467L13.4</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>aeb</author>
@@ -12854,6 +13164,8 @@
          <author_email>dm4</author_email>
          <remark>not for VEGA</remark>
          <remark>Annotation_remark- 3&apos; UTR for af2 pseudogene project  june 2012</remark>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-467L13.4-002</name>
          <exon_set>
@@ -12871,6 +13183,8 @@
          <stable_id>OTTHUMT00000402997</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-467L13.4-001</name>
          <evidence_set>
@@ -12904,6 +13218,7 @@
        <description>interferon induced transmembrane protein 3 (1-8U) (IFITM3) pseudogene</description>
        <name>RP11-467L13.5</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -12912,6 +13227,8 @@
          <stable_id>OTTHUMT00000402998</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-467L13.5-001</name>
          <evidence_set>
@@ -12941,6 +13258,7 @@
        <description>H3 histone, family 3C</description>
        <name>H3F3C</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -12950,6 +13268,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- based on cDNA BC066906</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-428G5.3-001</name>
          <translation_start>31792166</translation_start>
@@ -12986,6 +13306,7 @@
        <description>basic transcription factor 3-like 4 (BTF3L4) pseudogene</description>
        <name>RP11-428G5.4</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -12994,6 +13315,8 @@
          <stable_id>OTTHUMT00000402999</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-428G5.4-001</name>
          <evidence_set>
@@ -13023,6 +13346,7 @@
        <description>novel transcript</description>
        <name>RP11-428G5.5</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -13031,6 +13355,8 @@
          <stable_id>OTTHUMT00000403000</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-428G5.5-001</name>
          <evidence_set>
@@ -13064,6 +13390,7 @@
        <description>Impact homolog (mouse) (IMPACT) pseudogene</description>
        <name>RP11-428G5.6</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -13072,6 +13399,8 @@
          <stable_id>OTTHUMT00000403001</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-428G5.6-001</name>
          <evidence_set>
@@ -13105,6 +13434,7 @@
        <description>ribosomal protein, large, P2 (RPLP2) pseudogene</description>
        <name>RP11-428G5.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>mms</author>
@@ -13113,6 +13443,8 @@
          <stable_id>OTTHUMT00000349053</stable_id>
          <author>mms</author>
          <author_email>mms</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-428G5.1-001</name>
          <evidence_set>
@@ -13146,6 +13478,7 @@
        <description>ribosomal protein L12 (RPL12) pseudogene</description>
        <name>RP11-428G5.2</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -13154,6 +13487,8 @@
          <stable_id>OTTHUMT00000349059</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-428G5.2-001</name>
          <evidence_set>
@@ -13187,6 +13522,7 @@
        <description>family with sequence similarity 98, member B (FAM98B) pseudogene</description>
        <name>RP11-428G5.7</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -13195,6 +13531,8 @@
          <stable_id>OTTHUMT00000403002</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-428G5.7-001</name>
          <evidence_set>
@@ -13224,6 +13562,7 @@
        <description>KIAA1551</description>
        <name>KIAA1551</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <synonym>C12orf35</synonym>
@@ -13233,6 +13572,8 @@
          <stable_id>OTTHUMT00000403333</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC016957.1-004</name>
          <evidence_set>
@@ -13275,6 +13616,8 @@
          <remark>alternative 5&apos; UTR</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>AC016957.1-005</name>
          <translation_start>31980956</translation_start>
@@ -13324,6 +13667,8 @@
          <remark>Annotation_remark- CCDS8725.2</remark>
          <remark>Annotation_remark- corf</remark>
          <remark>Annotation_remark- extended by script extend_transcripts_to_polyA.pl</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>AC016957.1-001</name>
          <translation_start>31980956</translation_start>
@@ -13518,6 +13863,8 @@
          <stable_id>OTTHUMT00000403335</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC016957.1-006</name>
          <evidence_set>
@@ -13577,6 +13924,8 @@
          <stable_id>OTTHUMT00000403336</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC016957.1-007</name>
          <evidence_set>
@@ -13624,6 +13973,8 @@
          <stable_id>OTTHUMT00000403337</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC016957.1-008</name>
          <evidence_set>
@@ -13667,6 +14018,8 @@
          <remark>not organism-supported</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>AC016957.1-002</name>
          <translation_start>31980956</translation_start>
@@ -13709,6 +14062,8 @@
          <stable_id>OTTHUMT00000403339</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>AC016957.1-003</name>
          <evidence_set>
@@ -13742,6 +14097,7 @@
        <description>novel transcript</description>
        <name>RP11-50I19.2</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -13750,6 +14106,8 @@
          <stable_id>OTTHUMT00000474578</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-50I19.2-001</name>
          <evidence_set>
@@ -13779,6 +14137,7 @@
        <description>COX assembly mitochondrial protein homolog (S. cerevisiae) (CMC1) pseudogene</description>
        <name>RP11-50I19.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -13787,6 +14146,8 @@
          <stable_id>OTTHUMT00000403340</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-50I19.1-001</name>
          <evidence_set>
@@ -13820,6 +14181,7 @@
        <description>gamma-aminobutyric acid (GABA) A receptor, pi (GABRP) pseudogene</description>
        <name>RP11-843B15.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -13828,6 +14190,8 @@
          <stable_id>OTTHUMT00000403377</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-843B15.1-001</name>
          <evidence_set>
@@ -13861,6 +14225,7 @@
        <description>aurora kinase B (AURKB) pseudogene</description>
        <name>RP11-843B15.3</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>ib2</author>
@@ -13869,6 +14234,8 @@
          <stable_id>OTTHUMT00000469137</stable_id>
          <author>ib2</author>
          <author_email>ib2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-843B15.3-001</name>
          <evidence_set>
@@ -13894,6 +14261,7 @@
        <description>novel transcript</description>
        <name>RP11-843B15.2</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -13902,6 +14270,8 @@
          <stable_id>OTTHUMT00000403378</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-843B15.2-001</name>
          <evidence_set>
@@ -13943,6 +14313,7 @@
        <description>bicaudal D homolog 1 (Drosophila)</description>
        <name>BICD1</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -13952,6 +14323,8 @@
          <stable_id>OTTHUMT00000403880</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-208B19.1-005</name>
          <translation_start>32107332</translation_start>
@@ -13978,6 +14351,8 @@
          <stable_id>OTTHUMT00000403881</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-208B19.1-007</name>
          <translation_start>32107332</translation_start>
@@ -14013,6 +14388,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS44859.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-208B19.1-001</name>
          <translation_start>32107332</translation_start>
@@ -14116,6 +14493,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS8726.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-208B19.1-002</name>
          <translation_start>32107332</translation_start>
@@ -14222,6 +14601,8 @@
          <stable_id>OTTHUMT00000403381</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-208B19.1-003</name>
          <translation_start>32107332</translation_start>
@@ -14320,6 +14701,8 @@
          <stable_id>OTTHUMT00000403882</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-208B19.1-006</name>
          <translation_start>32107332</translation_start>
@@ -14364,6 +14747,8 @@
          <author_email>mpk</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-208B19.1-008</name>
          <translation_start>32328402</translation_start>
@@ -14404,6 +14789,8 @@
          <author_email>gm5</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-208B19.1-004</name>
          <translation_start>32334517</translation_start>
@@ -14454,6 +14841,8 @@
          <stable_id>OTTHUMT00000403884</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-208B19.1-009</name>
          <evidence_set>
@@ -14485,6 +14874,8 @@
          <stable_id>OTTHUMT00000474639</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-208B19.1-010</name>
          <evidence_set>
@@ -14514,6 +14905,7 @@
        <description>novel transcript, sense intronic to BICD1</description>
        <name>RP11-843B15.4</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -14523,6 +14915,8 @@
          <stable_id>OTTHUMT00000474581</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP11-843B15.4-001</name>
          <evidence_set>
@@ -14548,6 +14942,7 @@
        <description>WW domain binding protein 2 (WBP2) pseudogene</description>
        <name>RP11-956A19.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -14556,6 +14951,8 @@
          <stable_id>OTTHUMT00000403885</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-956A19.1-001</name>
          <evidence_set>
@@ -14589,6 +14986,7 @@
        <description>novel transcript, sense intronic to BICD1</description>
        <name>RP11-817I4.1</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -14598,6 +14996,8 @@
          <stable_id>OTTHUMT00000474620</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP11-817I4.1-001</name>
          <evidence_set>
@@ -14635,6 +15035,7 @@
        <description>novel transcript, sense intronic to BICD1</description>
        <name>RP11-817I4.2</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -14645,6 +15046,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- 3&apos; extended by approx. 13bp to cover polyAseq site (gm5, sept 2013)</remark>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP11-817I4.2-001</name>
          <evidence_set>
@@ -14686,6 +15089,7 @@
        <description>FYVE, RhoGEF and PH domain containing 4</description>
        <name>FGD4</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <remark>Annotation_remark- G2C</remark>
@@ -14696,6 +15100,8 @@
          <author>aeb</author>
          <author_email>aeb</author_email>
          <remark>not organism-supported</remark>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>AC090440.1-013</name>
          <translation_start>32399794</translation_start>
@@ -14858,6 +15264,8 @@
          <stable_id>OTTHUMT00000404119</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC090440.1-016</name>
          <evidence_set>
@@ -14897,6 +15305,8 @@
          <stable_id>OTTHUMT00000390887</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>AC090440.1-010</name>
          <translation_start>32486134</translation_start>
@@ -15056,6 +15466,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>alternative 5&apos; UTR</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>AC090440.1-005</name>
          <translation_start>32576358</translation_start>
@@ -15106,6 +15518,8 @@
          <stable_id>OTTHUMT00000268022</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>AC090440.1-006</name>
          <evidence_set>
@@ -15149,6 +15563,8 @@
          <stable_id>OTTHUMT00000268023</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC090440.1-007</name>
          <evidence_set>
@@ -15196,6 +15612,8 @@
          <stable_id>OTTHUMT00000268018</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>AC090440.1-002</name>
          <translation_start>32576358</translation_start>
@@ -15361,6 +15779,8 @@
          <remark>QC splicing correct</remark>
          <remark>dotter confirmed</remark>
          <remark>not organism-supported</remark>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>AC090440.1-014</name>
          <translation_start>32576358</translation_start>
@@ -15508,6 +15928,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS8727.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>AC090440.1-001</name>
          <translation_start>32576358</translation_start>
@@ -15778,6 +16200,8 @@
          <stable_id>OTTHUMT00000268024</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC090440.1-008</name>
          <evidence_set>
@@ -15825,6 +16249,8 @@
          <stable_id>OTTHUMT00000268019</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>AC090440.1-003</name>
          <translation_start>32576358</translation_start>
@@ -15979,6 +16405,8 @@
          <stable_id>OTTHUMT00000268025</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC090440.1-009</name>
          <evidence_set>
@@ -16035,6 +16463,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>not organism-supported</remark>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>AC090440.1-015</name>
          <translation_start>32582147</translation_start>
@@ -16185,6 +16615,8 @@
          <remark>Annotation_remark- gencode6_bVI_multi_698/chr12:32709808-32709929. novel RT-PCRseq exons checking for U Lausanne (23/02/2012 - ib2)</remark>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>AC090440.1-017</name>
          <translation_start>32576358</translation_start>
@@ -16235,6 +16667,8 @@
          <stable_id>OTTHUMT00000390888</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>AC090440.1-011</name>
          <translation_start>32534408</translation_start>
@@ -16399,6 +16833,8 @@
          <author_email>th2</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>AC090440.1-004</name>
          <translation_start>32582379</translation_start>
@@ -16571,6 +17007,7 @@
        <description>dynamin 1-like</description>
        <name>DNM1L</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>aeb</author>
@@ -16581,6 +17018,8 @@
          <author_email>th2</author_email>
          <remark>upstream ATG</remark>
          <remark>Annotation_remark- CCDS8730.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-8P13.2-001</name>
          <translation_start>32679364</translation_start>
@@ -16776,6 +17215,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- There is a human swissprot isoform for this (O00429-6) but it&apos;s not in otterlace?</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-8P13.2-002</name>
          <translation_start>32679364</translation_start>
@@ -16967,6 +17408,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS8729.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-8P13.2-003</name>
          <translation_start>32679364</translation_start>
@@ -17150,6 +17593,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>not organism-supported</remark>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>RP11-8P13.2-004</name>
          <translation_start>32679364</translation_start>
@@ -17324,6 +17769,8 @@
          <stable_id>OTTHUMT00000404126</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-8P13.2-022</name>
          <evidence_set>
@@ -17396,6 +17843,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS8728.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-8P13.2-005</name>
          <translation_start>32679364</translation_start>
@@ -17566,6 +18015,8 @@
          <stable_id>OTTHUMT00000404128</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.2-012</name>
          <evidence_set>
@@ -17609,6 +18060,8 @@
          <stable_id>OTTHUMT00000404129</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-8P13.2-013</name>
          <evidence_set>
@@ -17672,6 +18125,8 @@
          <stable_id>OTTHUMT00000404130</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-8P13.2-014</name>
          <translation_start>32679364</translation_start>
@@ -17732,6 +18187,8 @@
          <author_email>aeb</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>RP11-8P13.2-015</name>
          <translation_start>32679364</translation_start>
@@ -17808,6 +18265,8 @@
          <author_email>aeb</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>RP11-8P13.2-016</name>
          <translation_start>32679364</translation_start>
@@ -17866,6 +18325,8 @@
          <stable_id>OTTHUMT00000404133</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-8P13.2-017</name>
          <evidence_set>
@@ -17913,6 +18374,8 @@
          <stable_id>OTTHUMT00000404134</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-8P13.2-006</name>
          <translation_start>32679364</translation_start>
@@ -18003,6 +18466,8 @@
          <stable_id>OTTHUMT00000404135</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-8P13.2-007</name>
          <translation_start>32679364</translation_start>
@@ -18093,6 +18558,8 @@
          <stable_id>OTTHUMT00000404136</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-8P13.2-008</name>
          <translation_start>32679364</translation_start>
@@ -18267,6 +18734,8 @@
          <stable_id>OTTHUMT00000404137</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-8P13.2-009</name>
          <translation_start>32679364</translation_start>
@@ -18421,6 +18890,8 @@
          <stable_id>OTTHUMT00000404138</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>RP11-8P13.2-010</name>
          <translation_start>32679364</translation_start>
@@ -18601,6 +19072,8 @@
          <author_email>aeb</author_email>
          <mRNA_end_not_found>1</mRNA_end_not_found>
          <cds_end_not_found>1</cds_end_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>RP11-8P13.2-018</name>
          <translation_start>32679364</translation_start>
@@ -18675,6 +19148,8 @@
          <stable_id>OTTHUMT00000404140</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-8P13.2-019</name>
          <evidence_set>
@@ -18747,6 +19222,8 @@
          <remark>not organism-supported</remark>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-8P13.2-011</name>
          <translation_start>32701415</translation_start>
@@ -18901,6 +19378,8 @@
          <stable_id>OTTHUMT00000404142</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.2-020</name>
          <evidence_set>
@@ -18932,6 +19411,8 @@
          <stable_id>OTTHUMT00000404143</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.2-021</name>
          <evidence_set>
@@ -18979,6 +19460,8 @@
          <stable_id>OTTHUMT00000404144</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.2-024</name>
          <evidence_set>
@@ -19036,6 +19519,8 @@
          <author_email>th2</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-8P13.2-023</name>
          <translation_start>32731486</translation_start>
@@ -19110,6 +19595,8 @@
          <stable_id>OTTHUMT00000404146</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.2-025</name>
          <evidence_set>
@@ -19141,6 +19628,8 @@
          <stable_id>OTTHUMT00000404147</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.2-026</name>
          <evidence_set>
@@ -19180,6 +19669,8 @@
          <stable_id>OTTHUMT00000404148</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.2-027</name>
          <evidence_set>
@@ -19219,6 +19710,8 @@
          <stable_id>OTTHUMT00000404149</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.2-028</name>
          <evidence_set>
@@ -19258,6 +19751,8 @@
          <stable_id>OTTHUMT00000404150</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.2-029</name>
          <evidence_set>
@@ -19299,6 +19794,7 @@
        <description>mitochondrial assembly of ribosomal large subunit 1 (MALSU1) pseudogene</description>
        <name>RP11-278C7.2</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>mms</author>
@@ -19307,6 +19803,8 @@
          <stable_id>OTTHUMT00000404151</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-278C7.2-001</name>
          <evidence_set>
@@ -19332,6 +19830,7 @@
        <description>novel transcript, antisense to DNM1L</description>
        <name>RP11-278C7.4</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -19340,6 +19839,8 @@
          <stable_id>OTTHUMT00000474658</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-278C7.4-001</name>
          <evidence_set>
@@ -19365,6 +19866,7 @@
        <description>nucleosome assembly protein 1-like 1 (NAP1L1) pseudogene</description>
        <name>RP11-278C7.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -19373,6 +19875,8 @@
          <stable_id>OTTHUMT00000404152</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-278C7.1-001</name>
          <evidence_set>
@@ -19398,6 +19902,7 @@
        <description>tyrosyl-tRNA synthetase 2, mitochondrial</description>
        <name>YARS2</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -19407,6 +19912,8 @@
          <stable_id>OTTHUMT00000404447</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>RP11-8P13.3-003</name>
          <evidence_set>
@@ -19447,6 +19954,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS31770.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-8P13.3-001</name>
          <translation_start>32755874</translation_start>
@@ -19528,6 +20037,8 @@
          <remark>not organism-supported</remark>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-8P13.3-002</name>
          <translation_start>32755796</translation_start>
@@ -19592,6 +20103,7 @@
        <description>novel transcript, sense intronic to YARS2</description>
        <name>RP11-278C7.3</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -19601,6 +20113,8 @@
          <stable_id>OTTHUMT00000474649</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP11-278C7.3-001</name>
          <evidence_set>
@@ -19630,6 +20144,7 @@
        <description>novel transcript, sense intronic to YARS2</description>
        <name>RP11-278C7.5</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -19639,6 +20154,8 @@
          <stable_id>OTTHUMT00000474662</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP11-278C7.5-001</name>
          <evidence_set>
@@ -19664,6 +20181,7 @@
        <description>plakophilin 2</description>
        <name>PKP2</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -19674,6 +20192,8 @@
          <author>gm5</author>
          <author_email>gm5</author_email>
          <remark>Annotation_remark- CCDS31771.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-8P13.4-001</name>
          <translation_start>32896731</translation_start>
@@ -19817,6 +20337,8 @@
          <author>th2</author>
          <author_email>th2</author_email>
          <remark>Annotation_remark- CCDS8731.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-8P13.4-002</name>
          <translation_start>32896731</translation_start>
@@ -19955,6 +20477,8 @@
          <stable_id>OTTHUMT00000404492</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.4-007</name>
          <evidence_set>
@@ -19986,6 +20510,8 @@
          <stable_id>OTTHUMT00000404493</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.4-006</name>
          <evidence_set>
@@ -20017,6 +20543,8 @@
          <stable_id>OTTHUMT00000404494</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.4-005</name>
          <evidence_set>
@@ -20056,6 +20584,8 @@
          <stable_id>OTTHUMT00000404495</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-8P13.4-004</name>
          <evidence_set>
@@ -20097,6 +20627,8 @@
          <author_email>gm5</author_email>
          <mRNA_start_not_found>1</mRNA_start_not_found>
          <cds_start_not_found>1</cds_start_not_found>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-8P13.4-003</name>
          <translation_start>32896601</translation_start>
@@ -20145,6 +20677,7 @@
        <description>novel transcript, sense intronic to PKP2</description>
        <name>RP11-8P13.5</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -20154,6 +20687,8 @@
          <stable_id>OTTHUMT00000474669</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP11-8P13.5-001</name>
          <evidence_set>
@@ -20179,6 +20714,7 @@
        <description>ribosomal protein L35a (RPL35A) pseudogene</description>
        <name>RP11-8P13.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -20187,6 +20723,8 @@
          <stable_id>OTTHUMT00000349073</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-8P13.1-001</name>
          <evidence_set>
@@ -20224,6 +20762,7 @@
        <description>argininosuccinate synthase 1 (ASS1) pseudogene</description>
        <name>RP11-267D19.2</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -20232,6 +20771,8 @@
          <stable_id>OTTHUMT00000404497</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-267D19.2-001</name>
          <evidence_set>
@@ -20265,6 +20806,7 @@
        <description>novel transcript</description>
        <name>RP11-267D19.1</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>th2</author>
@@ -20273,6 +20815,8 @@
          <stable_id>OTTHUMT00000404498</stable_id>
          <author>th2</author>
          <author_email>th2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-267D19.1-001</name>
          <evidence_set>
@@ -20306,6 +20850,7 @@
        <description>synaptotagmin X</description>
        <name>SYT10</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -20317,6 +20862,8 @@
          <author_email>dm4</author_email>
          <remark>not organism-supported</remark>
          <remark>Annotation_remark- CCDS8732.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-438D14.1-001</name>
          <translation_start>33439522</translation_start>
@@ -20399,6 +20946,8 @@
          <stable_id>OTTHUMT00000403223</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-438D14.1-002</name>
          <translation_start>33439522</translation_start>
@@ -20491,6 +21040,8 @@
          <author_email>aeb</author_email>
          <remark>QC splicing correct</remark>
          <remark>dotter confirmed</remark>
+         <source>ensembl</source>
+         <type>ensembl:Putative</type>
          <transcript_class>Putative</transcript_class>
          <name>RP11-438D14.1-003</name>
          <evidence_set>
@@ -20524,6 +21075,7 @@
        <description>novel transcript, sense intronic to SYT10</description>
        <name>RP11-438D14.2</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -20533,6 +21085,8 @@
          <stable_id>OTTHUMT00000433919</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP11-438D14.2-001</name>
          <evidence_set>
@@ -20558,6 +21112,7 @@
        <description>novel transcript, sense intronic to SYT10</description>
        <name>RP11-438D14.3</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -20567,6 +21122,8 @@
          <stable_id>OTTHUMT00000474678</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP11-438D14.3-001</name>
          <evidence_set>
@@ -20592,6 +21149,7 @@
        <description>suppression of tumorigenicity 13 (colon carcinoma) (Hsp70 interacting protein) (ST13) pseudogene</description>
        <name>RP11-56H16.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>dm4</author>
@@ -20600,6 +21158,8 @@
          <stable_id>OTTHUMT00000403224</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-56H16.1-001</name>
          <evidence_set>
@@ -20625,6 +21185,7 @@
        <description>R3H domain and coiled-coil containing 1-like (R3HCC1L) pseudogene</description>
        <name>RP13-359K18.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>clb</author>
@@ -20633,6 +21194,8 @@
          <stable_id>OTTHUMT00000469160</stable_id>
          <author>clb</author>
          <author_email>clb</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP13-359K18.1-001</name>
          <evidence_set>
@@ -20658,6 +21221,7 @@
        <description>asparagine-linked glycosylation 10, alpha-1,2-glucosyltransferase homolog (S. pombe)</description>
        <name>ALG10</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>gm5</author>
@@ -20666,6 +21230,8 @@
          <stable_id>OTTHUMT00000403309</stable_id>
          <author>gm5</author>
          <author_email>gm5</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-847H18.1-001</name>
          <translation_start>34022600</translation_start>
@@ -20810,6 +21376,8 @@
          <author_email>aeb</author_email>
          <remark>QC splicing correct</remark>
          <remark>dotter confirmed</remark>
+         <source>ensembl</source>
+         <type>ensembl:Putative_CDS</type>
          <transcript_class>Putative_CDS</transcript_class>
          <name>RP11-847H18.1-004</name>
          <translation_start>34022600</translation_start>
@@ -20852,6 +21420,8 @@
          <stable_id>OTTHUMT00000403311</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Retained_intron</type>
          <transcript_class>Retained_intron</transcript_class>
          <name>RP11-847H18.1-003</name>
          <evidence_set>
@@ -20887,6 +21457,8 @@
          <stable_id>OTTHUMT00000403312</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>RP11-847H18.1-002</name>
          <translation_start>34022600</translation_start>
@@ -20943,6 +21515,7 @@
        <description>novel transcript, antisense to ALG10</description>
        <name>RP11-847H18.2</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -20951,6 +21524,8 @@
          <stable_id>OTTHUMT00000403313</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP11-847H18.2-001</name>
          <evidence_set>
@@ -20988,6 +21563,7 @@
        <description>novel transcript</description>
        <name>RP11-847H18.3</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -20996,6 +21572,8 @@
          <stable_id>OTTHUMT00000403314</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-847H18.3-001</name>
          <evidence_set>
@@ -21037,6 +21615,7 @@
        <description>novel transcript</description>
        <name>RP11-313F23.3</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>mms</author>
@@ -21045,6 +21624,8 @@
          <stable_id>OTTHUMT00000403315</stable_id>
          <author>mms</author>
          <author_email>mms</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-313F23.3-001</name>
          <evidence_set>
@@ -21086,6 +21667,7 @@
        <description>family with sequence similarity 41, member A, Y-linked 1 (FAM41AY1) pseudogene</description>
        <name>RP11-313F23.2</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>dm4</author>
@@ -21094,6 +21676,8 @@
          <stable_id>OTTHUMT00000403316</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP11-313F23.2-001</name>
          <evidence_set>
@@ -21123,6 +21707,7 @@
        <description>tubulin, beta 8 class VIII pseudogene 4</description>
        <name>TUBB8P4</name>
        <type>Unprocessed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>vb1</author>
@@ -21131,6 +21716,8 @@
          <stable_id>OTTHUMT00000373434</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Unprocessed_pseudogene</type>
          <transcript_class>Unprocessed_pseudogene</transcript_class>
          <name>RP11-313F23.1-001</name>
          <evidence_set>
@@ -21192,6 +21779,7 @@
        <description>novel transcript</description>
        <name>RP11-313F23.4</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -21201,6 +21789,8 @@
          <stable_id>OTTHUMT00000403317</stable_id>
          <author>mms</author>
          <author_email>mms</author_email>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-313F23.4-001</name>
          <evidence_set>
@@ -21250,6 +21840,7 @@
        <description>double homeobox, 4-like (DUX4) pseudogene</description>
        <name>RP11-313F23.5</name>
        <type>Transcribed_processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>overlapping locus</remark>
@@ -21260,6 +21851,8 @@
          <author>vb1</author>
          <author_email>vb1</author_email>
          <remark>Annotation_remark- changed biotype, extended transcript (vb1)</remark>
+         <source>ensembl</source>
+         <type>ensembl:Transcribed_processed_pseudogene</type>
          <transcript_class>Transcribed_processed_pseudogene</transcript_class>
          <name>RP11-313F23.5-001</name>
          <evidence_set>
@@ -21297,6 +21890,7 @@
        <description>TAF9 RNA polymerase II, TATA box binding protein (TBP)-associated factor, 32kDa (TAF9) pseudogene</description>
        <name>RP13-7D7.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>dm4</author>
@@ -21305,6 +21899,8 @@
          <stable_id>OTTHUMT00000403318</stable_id>
          <author>dm4</author>
          <author_email>dm4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP13-7D7.1-001</name>
          <evidence_set>

--- a/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
+++ b/t/etc/test_regions/human_test:chr2-38:929903-1379472.xml
@@ -194,6 +194,7 @@
        <description>novel transcript</description>
        <name>AC116614.1</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>clb</author>
@@ -202,6 +203,8 @@
          <stable_id>OTTHUMT00000322452</stable_id>
          <author>clb</author>
          <author_email>clb</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>AC116614.1-001</name>
          <evidence_set>
@@ -239,6 +242,7 @@
        <description>syntrophin, gamma 2</description>
        <name>SNTG2</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>lw2</author>
@@ -247,6 +251,8 @@
          <stable_id>OTTHUMT00000322407</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>AC114808.1-002</name>
          <translation_start>950997</translation_start>
@@ -329,6 +335,8 @@
          <stable_id>OTTHUMT00000322786</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Nonsense_mediated_decay</type>
          <transcript_class>Nonsense_mediated_decay</transcript_class>
          <name>AC114808.1-011</name>
          <translation_start>950997</translation_start>
@@ -412,6 +420,8 @@
          <author>lw2</author>
          <author_email>lw2</author_email>
          <remark>NP_061841</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>AC114808.1-001</name>
          <translation_start>950997</translation_start>
@@ -578,6 +588,8 @@
          <stable_id>OTTHUMT00000322455</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Novel_CDS</type>
          <transcript_class>Novel_CDS</transcript_class>
          <name>AC114808.1-003</name>
          <translation_start>950997</translation_start>
@@ -688,6 +700,8 @@
          <stable_id>OTTHUMT00000322456</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC114808.1-004</name>
          <evidence_set>
@@ -759,6 +773,8 @@
          <stable_id>OTTHUMT00000322460</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC114808.1-008</name>
          <evidence_set>
@@ -810,6 +826,8 @@
          <stable_id>OTTHUMT00000322787</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC114808.1-012</name>
          <evidence_set>
@@ -877,6 +895,8 @@
          <stable_id>OTTHUMT00000322457</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC114808.1-005</name>
          <evidence_set>
@@ -940,6 +960,8 @@
          <stable_id>OTTHUMT00000322461</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC114808.1-009</name>
          <evidence_set>
@@ -979,6 +1001,8 @@
          <stable_id>OTTHUMT00000322458</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC114808.1-006</name>
          <evidence_set>
@@ -1014,6 +1038,8 @@
          <stable_id>OTTHUMT00000322459</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC114808.1-007</name>
          <evidence_set>
@@ -1073,6 +1099,8 @@
          <stable_id>OTTHUMT00000322462</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC114808.1-010</name>
          <evidence_set>
@@ -1110,6 +1138,7 @@
        <description>novel transcript</description>
        <name>AC114808.3</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>clb</author>
@@ -1118,6 +1147,8 @@
          <stable_id>OTTHUMT00000322453</stable_id>
          <author>clb</author>
          <author_email>clb</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>AC114808.3-001</name>
          <evidence_set>
@@ -1155,6 +1186,7 @@
        <description>novel transcript</description>
        <name>AC114808.2</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>clb</author>
@@ -1163,6 +1195,8 @@
          <stable_id>OTTHUMT00000322450</stable_id>
          <author>clb</author>
          <author_email>clb</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>AC114808.2-001</name>
          <evidence_set>
@@ -1204,6 +1238,7 @@
        <description>novel transcript</description>
        <name>AC108462.1</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>clb</author>
@@ -1212,6 +1247,8 @@
          <stable_id>OTTHUMT00000322451</stable_id>
          <author>clb</author>
          <author_email>clb</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>AC108462.1-001</name>
          <evidence_set>
@@ -1245,6 +1282,7 @@
        <description>thyroid peroxidase</description>
        <name>TPO</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>1</truncated>
        <remark>Transcript &apos;AC141930.1-001&apos; has no exons within the slice</remark>
@@ -1265,6 +1303,8 @@
          <stable_id>OTTHUMT00000353107</stable_id>
          <author>lw2</author>
          <author_email>lw2</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC141930.1-011</name>
          <evidence_set>

--- a/t/etc/test_regions/human_test:chr6-38:2557766-2647766.xml
+++ b/t/etc/test_regions/human_test:chr6-38:2557766-2647766.xml
@@ -40,6 +40,7 @@
        <description>TEC</description>
        <name>RP11-299J5.1</name>
        <type>TEC</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>mg13</author>
@@ -48,6 +49,8 @@
          <stable_id>OTTHUMT00000431233</stable_id>
          <author>mg13</author>
          <author_email>mg13</author_email>
+         <source>ensembl</source>
+         <type>ensembl:TEC</type>
          <transcript_class>TEC</transcript_class>
          <name>RP11-299J5.1-001</name>
          <evidence_set>
@@ -81,6 +84,7 @@
        <description>chromosome 6 open reading frame 195</description>
        <name>C6orf195</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <synonym>RP11-145H9.2</synonym>
@@ -92,6 +96,8 @@
          <author>anacode</author>
          <author_email>anacode</author_email>
          <remark>novel protein (FLJ31934)</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>RP11-145H9.2-001</name>
          <translation_start>2623822</translation_start>
@@ -140,6 +146,7 @@
        <description>novel transcript</description>
        <name>RP11-145H9.3</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <synonym>bA145H9.3</synonym>
@@ -150,6 +157,8 @@
          <author>anacode</author>
          <author_email>anacode</author_email>
          <remark>novel transcript</remark>
+         <source>ensembl</source>
+         <type>ensembl:lincRNA</type>
          <transcript_class>lincRNA</transcript_class>
          <name>RP11-145H9.3-001</name>
          <evidence_set>

--- a/t/etc/test_regions/mouse:chr1-38:3009920-3786391.xml
+++ b/t/etc/test_regions/mouse:chr1-38:3009920-3786391.xml
@@ -109,6 +109,7 @@
        <description>TEC</description>
        <name>RP23-271O17.1</name>
        <type>TEC</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -117,6 +118,8 @@
          <stable_id>OTTMUST00000127109</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:TEC</type>
          <transcript_class>TEC</transcript_class>
          <name>RP23-271O17.1-001</name>
          <evidence_set>
@@ -142,6 +145,7 @@
        <description>X Kell blood group precursor related family member 4</description>
        <name>Xkr4</name>
        <type>Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -150,6 +154,8 @@
          <stable_id>OTTMUST00000086625</stable_id>
          <author>mt4</author>
          <author_email>mt4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC157543.1-003</name>
          <evidence_set>
@@ -181,6 +187,8 @@
          <stable_id>OTTMUST00000086624</stable_id>
          <author>mt4</author>
          <author_email>mt4</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Transcript</type>
          <transcript_class>Transcript</transcript_class>
          <name>AC157543.1-002</name>
          <evidence_set>
@@ -213,6 +221,8 @@
          <author>al1</author>
          <author_email>al1</author_email>
          <remark>Annotation_remark- CCDS14803.1</remark>
+         <source>ensembl</source>
+         <type>ensembl:Known_CDS</type>
          <transcript_class>Known_CDS</transcript_class>
          <name>AC157543.1-001</name>
          <translation_start>3671348</translation_start>
@@ -265,6 +275,7 @@
        <description>X Kell blood group precursor related family member 4</description>
        <name>KO:Xkr4</name>
        <type>KO:Known_CDS</type>
+       <source>havana</source>
        <known>1</known>
        <truncated>0</truncated>
        <author>am9</author>
@@ -274,6 +285,8 @@
          <author>am9</author>
          <author_email>am9</author_email>
          <remark>based on OTTMUST00000065166</remark>
+         <source>ensembl</source>
+         <type>ensembl:Coding</type>
          <transcript_class>Coding</transcript_class>
          <name>KO:AC157543.1-001</name>
          <translation_start>3671348</translation_start>
@@ -304,6 +317,7 @@
        <description>coenzyme Q2 4-hydroxybenzoate polyprenyltransferase (COQ2) pseudogene</description>
        <name>RP23-317L18.1</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -314,6 +328,8 @@
          <author_email>al1</author_email>
          <remark>Gm18956</remark>
          <remark>predicted gene, 18956</remark>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP23-317L18.1-001</name>
          <evidence_set>
@@ -347,6 +363,7 @@
        <description>artifact gene</description>
        <name>RP23-317L18.2</name>
        <type>Artifact</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -355,6 +372,8 @@
          <stable_id>OTTMUST00000127144</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Artifact</type>
          <transcript_class>Artifact</transcript_class>
          <name>RP23-317L18.2-001</name>
          <evidence_set>
@@ -380,6 +399,7 @@
        <description>TEC</description>
        <name>RP23-317L18.4</name>
        <type>TEC</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -388,6 +408,8 @@
          <stable_id>OTTMUST00000127145</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:TEC</type>
          <transcript_class>TEC</transcript_class>
          <name>RP23-317L18.4-001</name>
          <evidence_set>
@@ -413,6 +435,7 @@
        <description>TEC</description>
        <name>RP23-317L18.3</name>
        <type>TEC</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -421,6 +444,8 @@
          <stable_id>OTTMUST00000127146</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:TEC</type>
          <transcript_class>TEC</transcript_class>
          <name>RP23-317L18.3-001</name>
          <evidence_set>
@@ -446,6 +471,7 @@
        <description>artifact gene</description>
        <name>RP23-115I1.7</name>
        <type>Artifact</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -454,6 +480,8 @@
          <stable_id>OTTMUST00000127147</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Artifact</type>
          <transcript_class>Artifact</transcript_class>
          <name>RP23-115I1.7-001</name>
          <evidence_set>
@@ -479,6 +507,7 @@
        <description>TEC</description>
        <name>RP23-115I1.6</name>
        <type>TEC</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -487,6 +516,8 @@
          <stable_id>OTTMUST00000127101</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:TEC</type>
          <transcript_class>TEC</transcript_class>
          <name>RP23-115I1.6-001</name>
          <evidence_set>
@@ -520,6 +551,7 @@
        <description>novel transcript, antisense to Xkr4</description>
        <name>RP23-115I1.1</name>
        <type>Novel_Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <remark>Annotation_remark- Gene originally annotated by WU</remark>
@@ -529,6 +561,8 @@
          <stable_id>OTTMUST00000065165</stable_id>
          <author>cas</author>
          <author_email>cas</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Antisense</type>
          <transcript_class>Antisense</transcript_class>
          <name>RP23-115I1.1-001</name>
          <evidence_set>
@@ -562,6 +596,7 @@
        <description>TEC</description>
        <name>RP23-115I1.5</name>
        <type>TEC</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -570,6 +605,8 @@
          <stable_id>OTTMUST00000127100</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:TEC</type>
          <transcript_class>TEC</transcript_class>
          <name>RP23-115I1.5-001</name>
          <evidence_set>
@@ -603,6 +640,7 @@
        <description>solute carrier family 35, member E3 (Slc35e3) pseudogene</description>
        <name>RP23-115I1.2</name>
        <type>Processed_pseudogene</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -613,6 +651,8 @@
          <author_email>al1</author_email>
          <remark>Gm7341</remark>
          <remark>predicted gene 7341</remark>
+         <source>ensembl</source>
+         <type>ensembl:Processed_pseudogene</type>
          <transcript_class>Processed_pseudogene</transcript_class>
          <name>RP23-115I1.2-001</name>
          <evidence_set>
@@ -646,6 +686,7 @@
        <description>artifact gene</description>
        <name>RP23-115I1.4</name>
        <type>Artifact</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -654,6 +695,8 @@
          <stable_id>OTTMUST00000127099</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Artifact</type>
          <transcript_class>Artifact</transcript_class>
          <name>RP23-115I1.4-001</name>
          <evidence_set>
@@ -679,6 +722,7 @@
        <description>TEC</description>
        <name>RP23-115I1.3</name>
        <type>TEC</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -687,6 +731,8 @@
          <stable_id>OTTMUST00000127098</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:TEC</type>
          <transcript_class>TEC</transcript_class>
          <name>RP23-115I1.3-001</name>
          <evidence_set>
@@ -712,6 +758,7 @@
        <description>novel transcript, sense overlapping Xkr4</description>
        <name>RP23-122M2.3</name>
        <type>Transcript</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -720,6 +767,8 @@
          <stable_id>OTTMUST00000127092</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:Sense_intronic</type>
          <transcript_class>Sense_intronic</transcript_class>
          <name>RP23-122M2.3-001</name>
          <evidence_set>
@@ -761,6 +810,7 @@
        <description>TEC</description>
        <name>RP23-122M2.2</name>
        <type>TEC</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -771,6 +821,8 @@
          <author_email>al1</author_email>
          <remark>Gm10568</remark>
          <remark>predicted gene 10568</remark>
+         <source>ensembl</source>
+         <type>ensembl:TEC</type>
          <transcript_class>TEC</transcript_class>
          <name>RP23-122M2.2-001</name>
          <evidence_set>
@@ -804,6 +856,7 @@
        <description>TEC</description>
        <name>RP23-122M2.1</name>
        <type>TEC</type>
+       <source>havana</source>
        <known>0</known>
        <truncated>0</truncated>
        <author>al1</author>
@@ -812,6 +865,8 @@
          <stable_id>OTTMUST00000127091</stable_id>
          <author>al1</author>
          <author_email>al1</author_email>
+         <source>ensembl</source>
+         <type>ensembl:TEC</type>
          <transcript_class>TEC</transcript_class>
          <name>RP23-122M2.1-001</name>
          <evidence_set>


### PR DESCRIPTION
By default the source is havana. Because we are working on NoMerge,
the source in the Loutre database can be ensembl_havana, havana or
ensembl. When an annotator modify an ensembl transcript, it becomes
an ensembl_havana transcript and the gene also has the ensembl_havana
source.

There is some hack for the client so it send a message to Zmap so the
transcript is redrawn is the correct track