### PR TITLE
Code to fix unnecessary save trigger when an ensembl transcript is opened

### DIFF
--- a/modules/MenuCanvasWindow/SessionWindow.pm
+++ b/modules/MenuCanvasWindow/SessionWindow.pm
@@ -71,7 +71,7 @@ use Tk::ArrayBar;
 use Tk::Screens;
 use Tk::ScopedBusy;
 use Bio::Vega::Utils::MacProxyConfig qw{ mac_os_x_set_proxy_vars };
-use Data::Dumper;
+
 use base qw{
     MenuCanvasWindow
     Bio::Otter::UI::ZMapSelectMixin

--- a/modules/MenuCanvasWindow/SessionWindow.pm
+++ b/modules/MenuCanvasWindow/SessionWindow.pm
@@ -71,7 +71,7 @@ use Tk::ArrayBar;
 use Tk::Screens;
 use Tk::ScopedBusy;
 use Bio::Vega::Utils::MacProxyConfig qw{ mac_os_x_set_proxy_vars };
-
+use Data::Dumper;
 use base qw{
     MenuCanvasWindow
     Bio::Otter::UI::ZMapSelectMixin
@@ -2613,6 +2613,9 @@ sub _replace_SubSeq_sqlite {
                 $self->logger->debug("$new_subseq_name: diffs to original saved SubSeq.");
                 $self->_log_diffs($diffs, "SubSeq $new_subseq_name");
                 $from_HumAce->update_Transcript($new_subseq, $old_subseq, $diffs);
+                if ($self->_locus_cache->get($new_locus_name)->gene_type_prefix eq 'ensembl') {
+                    $self->_locus_cache->get($new_locus_name)->gene_type_prefix('');
+                }
             } else {
                 $self->logger->debug("$new_subseq_name: no diffs so nothing else to do.");
             }

--- a/modules/MenuCanvasWindow/TranscriptWindow.pm
+++ b/modules/MenuCanvasWindow/TranscriptWindow.pm
@@ -1275,6 +1275,9 @@ sub _get_Locus_from_tk {
     if ($name =~ /^([^:]+):/) {
         $locus->gene_type_prefix($1);
     }
+    if (! $locus->gene_type_prefix) {
+        $locus->gene_type_prefix($self->{'_SubSeq'}{'_Locus'}{'_gene_type_prefix'});
+    }
     $locus->description($desc) if $desc;
     $locus->set_aliases(@aliases);
 

--- a/modules/MenuCanvasWindow/TranscriptWindow.pm
+++ b/modules/MenuCanvasWindow/TranscriptWindow.pm
@@ -48,7 +48,7 @@ use CanvasWindow::EvidencePaster;
 use EditWindow::PfamWindow;
 use Bio::Otter::Lace::Client;
 use Bio::Otter::UI::TextWindow::Peptide;
-
+use Data::Dumper;
 use base qw( MenuCanvasWindow );
 
 # "new" is in MenuCanvasWindow
@@ -1276,7 +1276,7 @@ sub _get_Locus_from_tk {
         $locus->gene_type_prefix($1);
     }
     if (! $locus->gene_type_prefix) {
-        $locus->gene_type_prefix($self->{'_SubSeq'}{'_Locus'}{'_gene_type_prefix'});
+        $locus->gene_type_prefix($self->SubSeq->Locus->gene_type_prefix);
     }
     $locus->description($desc) if $desc;
     $locus->set_aliases(@aliases);

--- a/modules/MenuCanvasWindow/TranscriptWindow.pm
+++ b/modules/MenuCanvasWindow/TranscriptWindow.pm
@@ -48,7 +48,7 @@ use CanvasWindow::EvidencePaster;
 use EditWindow::PfamWindow;
 use Bio::Otter::Lace::Client;
 use Bio::Otter::UI::TextWindow::Peptide;
-use Data::Dumper;
+
 use base qw( MenuCanvasWindow );
 
 # "new" is in MenuCanvasWindow


### PR DESCRIPTION
In SessionWindow.pm, where the transcript is updated, `$new_subseq->Locus->gene_type_prefix = ' '`. I'm unsure if this has to be reset. 

Further testing is required. 