### PR TITLE
Code to generate correct Ensembl stable ID

### DIFF
--- a/modules/Bio/Vega/DBSQL/StableIdAdaptor.pm
+++ b/modules/Bio/Vega/DBSQL/StableIdAdaptor.pm
@@ -65,13 +65,11 @@ sub _fetch_new_by_type {
 
     my $meta_container = $self->db->get_MetaContainer;
     my $prefix =
-        ($meta_container->get_primary_prefix || 'ENS')
-      . ($meta_container->get_species_prefix || '')
+        $meta_container->single_value_by_key('species.stable_id_prefix')
       . $type_prefix;
 
-    # Stable IDs are always 18 characters long
-    my $rem = 18 - length($prefix);
-    return $prefix . sprintf "\%0${rem}d", $num;
+    # Stable IDs are species prefix + type prefix + 11 digit number. This has been changed from the existing 18 digit stable id generation which was Loutre DB based. 
+    return $prefix . sprintf "\%011d", $num;
 }
 
 1;


### PR DESCRIPTION
The code now generates the stable ID with the correct length. This has been tested and approved by the annotators. 