### PR TITLE
The code adds the new locus to the locus cache

### DIFF
--- a/modules/MenuCanvasWindow/SessionWindow.pm
+++ b/modules/MenuCanvasWindow/SessionWindow.pm
@@ -2555,6 +2555,7 @@ sub _replace_SubSeq_sqlite {
     my $new_locus = $new_subseq->Locus;
     my $old_locus = $old_subseq->Locus;
 
+    my $new_locus_name = $new_locus->name;
     if (!$self->_locus_cache->get($new_locus_name) ) {
        $self->_locus_cache->set($new_locus);
     }

--- a/modules/MenuCanvasWindow/SessionWindow.pm
+++ b/modules/MenuCanvasWindow/SessionWindow.pm
@@ -2555,7 +2555,10 @@ sub _replace_SubSeq_sqlite {
     my $new_locus = $new_subseq->Locus;
     my $old_locus = $old_subseq->Locus;
 
-    my $new_locus_name = $new_locus->name;
+    if (!$self->_locus_cache->get($new_locus_name) ) {
+       $self->_locus_cache->set($new_locus);
+    }
+
     my $old_locus_name = $old_locus->name || $new_locus_name;
     my $locus_tag  = "Locus $new_locus_name for SubSeq $new_subseq_name";
 


### PR DESCRIPTION
When the locus symbol is changed, it does not get updated in the locus cache. This causes issue when trying to fix the gene_type_prefix for the new locus. This PR fixes this issue. Extensive testing will be required. 