### PR TITLE
Dafault values insert replaced with new syntax

### DIFF
--- a/modules/Bio/Vega/DBSQL/StableIdAdaptor.pm
+++ b/modules/Bio/Vega/DBSQL/StableIdAdaptor.pm
@@ -58,7 +58,7 @@ sub _fetch_new_by_type {
     my $poolid = $type . "_pool_id";
     my $table  = $type . "_stable_id_pool";
 
-    my $sql = "insert into $table () values()";
+    my $sql = "insert into $table DEFAULT VALUES";
     my $sth = $self->prepare($sql);
     $sth->execute;
     my $num = $self->last_insert_id($poolid, undef, $table) or throw("Failed to get autoincremented '$poolid'");


### PR DESCRIPTION
Resolving issues 3370, 3410, 3460. 
In all this cases we are having error:  'DBD::SQLite::db prepare failed: near ")": syntax error .....

It is caused when we are executing at sqlite  expression `insert into $table () values()` - which is not valid for new version of sqlite, and means inserting of default values.

So the fix is to replace with correct sqlite query for default values insert.