### PR TITLE
Changes made for fetchdb to work in ZMap

### DIFF
--- a/scripts/apache/nfetch
+++ b/scripts/apache/nfetch
@@ -14,10 +14,6 @@ use Bio::Otter::Utils::AccessionInfo;
 
     eval {
         $q = CGI->new;
-
-        my $sw = SangerWeb->new({ cgi => $q });
-        die "Not authorized\n"
-          unless $sw->username;
     };
 
     if ($@) {


### PR DESCRIPTION
FetchDB in ZMap and Blixem did not work because of Sanger authentication in the code. This has been resolved by removing those code lines. 