### PR TITLE
Add supporting evidences when cloning object

### DIFF
--- a/modules/Bio/Vega/Exon.pm
+++ b/modules/Bio/Vega/Exon.pm
@@ -43,6 +43,11 @@ sub new_dissociated_copy {
         )
                                });
 
+    foreach my $sf (@{$self->get_all_supporting_features}) {
+      my %tmp_sf = %$sf;
+      my $new_sf = ref($sf)->new_fast(\%tmp_sf);
+      $copy->add_supporting_features($new_sf);
+    }
     return $copy;
 }
 

--- a/modules/Bio/Vega/Transcript.pm
+++ b/modules/Bio/Vega/Transcript.pm
@@ -97,6 +97,11 @@ sub new_dissociated_copy {
         push @evidence_list, $ev_pkg->new(-name => $ev->name, -type => $ev->type);
     }
     $copy->evidence_list(\@evidence_list);
+    foreach my $tsf (@{$self->get_all_supporting_features}) {
+      my %tmp_tsf = %$tsf;
+      my $new_tsf = ref($tsf)->new_fast(\%tmp_tsf);
+      $copy->add_supporting_features($new_tsf);
+    }
 
     $copy->translation($translation->new_dissociated_copy($copy, $new_start_exon, $new_end_exon)) if $translation;
 


### PR DESCRIPTION
The new_dissociated_copy method in Exon and Transcript was not copying
the supporting evidence. So the supporting evidences would be lost each
time the method is used

This addition may have an impact on the performance of the code as some models will have many supporting evidence. So maybe it is better to have it as a new method