### PR TITLE
Add human_training db to species list

### DIFF
--- a/modules/Bio/Otter/Server/UserSpecies.pm
+++ b/modules/Bio/Otter/Server/UserSpecies.pm
@@ -36,7 +36,7 @@ sub species_group{
  my %final_species_groups = query_links($dbh);
  
  # Setting up 'dev','main', 'restricted' and 'mouse_strain' species groups
- $final_species_groups{'species_groups'}{'dev'} = [ 'human_test'];
+ $final_species_groups{'species_groups'}{'dev'} = ['human_test', 'human_training'];
  $final_species_groups{'species_groups'}{'main'} = ['c_elegans', 'cat', 'chicken', 'chimp', 'cow', 'dog', 'drosophila', 'gibbon', 'gorilla', 'herring', 'herring_test', 'human', 'lemur', 'marmoset', 'medicago', 'mouse', 'mus_spretus', 'opossum', 'pig', 'platypus', 'rat', 'sheep', 'sordaria', 'tas_devil', 'tomato', 'tropicalis', 'wallaby', 'wheat', 'zebrafish']; 
  $final_species_groups{'species_groups'}{'mouse_strains'} = ['mouse-SPRET-EiJ', 'mouse-PWK-PhJ', 'mouse-CAST-EiJ', 'mouse-WSB-EiJ', 'mouse-NZO-HlLtJ', 'mouse-C57BL-6NJ', 'mouse-NOD-ShiLtJ', 'mouse-FVB-NJ', 'mouse-DBA-2J', 'mouse-CBA-J', 'mouse-C3H-HeJ', 'mouse-AKR-J', 'mouse-BALB-cJ', 'mouse-A-J', 'mouse-LP-J', 'mouse-129S1-SvImJ', 'mouse-C57BL-6NJ_v1_test'];
  $final_species_groups{'species_groups'}{'restricted'} =['human_test','mouse_test', 'mouse_old', 'mouse_old_test'];


### PR DESCRIPTION
A new database is being integrated into Otter for training purposes, which will be called `human_training` in Otter.

`human_training` is being added in here as a new 'species'  to UserSpecies.pm, which will hopefully allow Otter to recognise this as a new database to request access to.