### PR TITLE
Add human_training to species list for Test Otter

### DIFF
--- a/modules/Bio/Otter/Server/UserSpecies.pm
+++ b/modules/Bio/Otter/Server/UserSpecies.pm
@@ -36,7 +36,7 @@ sub species_group{
  my %final_species_groups = query_links($dbh);
  
  # Setting up 'dev','main', 'restricted' and 'mouse_strain' species groups
- $final_species_groups{'species_groups'}{'dev'} = [ 'human_test'];
+ $final_species_groups{'species_groups'}{'dev'} = ['human_test','human_training'];
  $final_species_groups{'species_groups'}{'main'} = ['c_elegans', 'cat', 'chicken', 'chimp', 'cow', 'dog', 'drosophila', 'gibbon', 'gorilla', 'herring', 'herring_test', 'human', 'lemur', 'marmoset', 'medicago', 'mouse', 'mus_spretus', 'opossum', 'pig', 'platypus', 'rat', 'sheep', 'sordaria', 'tas_devil', 'tomato', 'tropicalis', 'wallaby', 'wheat', 'zebrafish']; 
  $final_species_groups{'species_groups'}{'mouse_strains'} = ['mouse-SPRET-EiJ', 'mouse-PWK-PhJ', 'mouse-CAST-EiJ', 'mouse-WSB-EiJ', 'mouse-NZO-HlLtJ', 'mouse-C57BL-6NJ', 'mouse-NOD-ShiLtJ', 'mouse-FVB-NJ', 'mouse-DBA-2J', 'mouse-CBA-J', 'mouse-C3H-HeJ', 'mouse-AKR-J', 'mouse-BALB-cJ', 'mouse-A-J', 'mouse-LP-J', 'mouse-129S1-SvImJ', 'mouse-C57BL-6NJ_v1_test'];
  $final_species_groups{'species_groups'}{'restricted'} =['human_test','mouse_test', 'mouse_old', 'mouse_old_test'];


### PR DESCRIPTION
Investigations of a 417 error have found that Test Otter does not have access to the new human_training data set. These changes are to be pushed against the code branch `test_server_client` so that Test Otter can access this data set (already pushed to master and working fine for Production Otter).