### PR TITLE
Select sequence type (DNA, Protein) in OTF window

### DIFF
--- a/modules/Bio/Otter/Lace/Client.pm
+++ b/modules/Bio/Otter/Lace/Client.pm
@@ -1181,9 +1181,9 @@ sub _get_DataSets_hash {
 }
 
 sub fetch_fasta_seqence {
-    my ($self, $acc) = @_;
+    my ($self, $acc, $seq_target) = @_;
     my $datasets_hash = $self->otter_response_content
-        ('GET', 'get_fasta_sequence', {'id'=>$acc, 'author' => $self->author});
+        ('GET', 'get_fasta_sequence', {'id'=>$acc, 'sequence_target'=>$seq_target, 'author' => $self->author});
 
     return $datasets_hash;
 }

--- a/modules/Bio/Otter/Lace/Client.pm
+++ b/modules/Bio/Otter/Lace/Client.pm
@@ -1181,9 +1181,9 @@ sub _get_DataSets_hash {
 }
 
 sub fetch_fasta_seqence {
-    my ($self, $acc, $seq_target) = @_;
+    my ($self, $acc, $seq_type) = @_;
     my $datasets_hash = $self->otter_response_content
-        ('GET', 'get_fasta_sequence', {'id'=>$acc, 'sequence_target'=>$seq_target, 'author' => $self->author});
+        ('GET', 'get_fasta_sequence', {'id'=>$acc, 'sequence_type'=>$seq_type, 'author' => $self->author});
 
     return $datasets_hash;
 }

--- a/modules/Bio/Otter/Lace/OnTheFly/QueryValidator.pm
+++ b/modules/Bio/Otter/Lace/OnTheFly/QueryValidator.pm
@@ -39,7 +39,7 @@ has accession_type_cache => ( is => 'ro', isa => 'Bio::Otter::Lace::AccessionTyp
 has seqs                 => ( is => 'ro', isa => 'ArrayRef[Hum::Sequence]', default => sub{ [] } );
 has accessions           => ( is => 'ro', isa => 'ArrayRef[Str]',           default => sub{ [] } );
 
-has sequence_target      => ( is => 'ro', isa => 'Str', default => 'dna');
+has sequence_type      => ( is => 'ro', isa => 'Str', default => 'dna');
 
 has lowercase_poly_a_t_tails => ( is => 'ro', isa => 'Bool', default => undef );
 
@@ -97,10 +97,10 @@ sub _build_confirmed_seqs {     ## no critic (Subroutines::ProhibitUnusedPrivate
         $cache->populate(\@accessions);
     }
 
-    my $seq_target = $self->sequence_target;
+    my $seq_type = $self->sequence_type;
     $self->_augment_supplied_sequences;
     my @to_fetch = $self->_check_augment_supplied_accessions;
-    $self->_fetch_sequences($seq_target, @to_fetch);
+    $self->_fetch_sequences($seq_type, @to_fetch);
 
     # tell the user about any missing sequences or remapped accessions
 
@@ -241,7 +241,7 @@ sub Client {
 # Adds sequences to $self->seqs
 #
 sub _fetch_sequences {
-    my ($self, $seq_target, @to_fetch) = @_;
+    my ($self, $seq_type, @to_fetch) = @_;
 
     my $cache = $self->accession_type_cache;
 
@@ -250,7 +250,7 @@ sub _fetch_sequences {
     my $client = Bio::Otter::Lace::Defaults::make_Client();
     foreach my $acc (@to_fetch) {
 
-        my $seq = $client->fetch_fasta_seqence($acc, $seq_target);
+        my $seq = $client->fetch_fasta_seqence($acc, $seq_type);
         if (substr($seq, 0, 1) eq ">") {
           $seq = $self->parse_fasta_sequence($seq);
           push(@{$self->seqs}, $seq);

--- a/modules/EditWindow/Exonerate.pm
+++ b/modules/EditWindow/Exonerate.pm
@@ -55,9 +55,9 @@ my $MASK_TARGET_NONE    = 'none';
 my $MASK_TARGET_SOFT    = 'soft';
 my $MASK_TARGET_DEFAULT = $MASK_TARGET_NONE;
 
-my $SEQ_TARGET_PROTEIN   = 'protein';
-my $SEQ_TARGET_DNA    = 'dna';
-my $SEQ_TARGET_DEFAULT = $SEQ_TARGET_DNA;
+my $SEQ_TYPE_PROTEIN   = 'protein';
+my $SEQ_TYPE_DNA    = 'dna';
+my $SEQ_TYPE_DEFAULT = $SEQ_TYPE_DNA;
 
 my $INITIAL_DIR = (getpwuid($<))[7];
 
@@ -190,10 +190,10 @@ sub initialise {
            [ 'Unmasked',    $MASK_TARGET_NONE ],
            [ 'Soft masked', $MASK_TARGET_SOFT ],
           ] ],
-        [ '_sequence_target', $SEQ_TARGET_DEFAULT, 'Sequence',
+        [ '_sequence_type', $SEQ_TYPE_DEFAULT, 'Sequence',
           [
-           [ 'Protein', $SEQ_TARGET_PROTEIN ],
-           [ 'DNA', $SEQ_TARGET_DNA ],
+           [ 'Protein', $SEQ_TYPE_PROTEIN ],
+           [ 'DNA', $SEQ_TYPE_DNA ],
           ] ]
         ];
 
@@ -529,7 +529,7 @@ sub launch_exonerate {
         repeat_masker   => sub { my $apply_mask_sub = shift; $self->_repeat_masker($apply_mask_sub); },
 
         softmask_target => ($self->{_mask_target} eq $MASK_TARGET_SOFT),
-        sequence_target => $self->{_sequence_target},
+        sequence_type => $self->{_sequence_type},
         bestn           => $bestn,
         maxintron       => $maxintron,
 

--- a/modules/EditWindow/Exonerate.pm
+++ b/modules/EditWindow/Exonerate.pm
@@ -55,6 +55,10 @@ my $MASK_TARGET_NONE    = 'none';
 my $MASK_TARGET_SOFT    = 'soft';
 my $MASK_TARGET_DEFAULT = $MASK_TARGET_NONE;
 
+my $SEQ_TARGET_PROTEIN   = 'protein';
+my $SEQ_TARGET_DNA    = 'dna';
+my $SEQ_TARGET_DEFAULT = $SEQ_TARGET_DNA;
+
 my $INITIAL_DIR = (getpwuid($<))[7];
 
 sub initialise {
@@ -186,6 +190,11 @@ sub initialise {
            [ 'Unmasked',    $MASK_TARGET_NONE ],
            [ 'Soft masked', $MASK_TARGET_SOFT ],
           ] ],
+        [ '_sequence_target', $SEQ_TARGET_DEFAULT, 'Sequence',
+          [
+           [ 'Protein', $SEQ_TARGET_PROTEIN ],
+           [ 'DNA', $SEQ_TARGET_DNA ],
+          ] ]
         ];
 
     for (@{$input_widgets}) {
@@ -520,6 +529,7 @@ sub launch_exonerate {
         repeat_masker   => sub { my $apply_mask_sub = shift; $self->_repeat_masker($apply_mask_sub); },
 
         softmask_target => ($self->{_mask_target} eq $MASK_TARGET_SOFT),
+        sequence_target => $self->{_sequence_target},
         bestn           => $bestn,
         maxintron       => $maxintron,
 
@@ -700,4 +710,3 @@ __END__
 =head1 AUTHOR
 
 Ana Code B<email> anacode@sanger.ac.uk
-

--- a/scripts/apache/get_fasta_sequence
+++ b/scripts/apache/get_fasta_sequence
@@ -47,11 +47,12 @@ sub get_fasta_sequence {
         push @queries, $query;
     }
 
-    $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?format=fasta&style=raw&db=refseqn&id=';
-    push @queries, $query;
-    $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=ena_sequence&format=fasta&style=raw&Retrieve=Retrieve&id=';
-
-    push @queries, $query;
+    if($seq_type eq 'dna') {
+        $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?format=fasta&style=raw&db=refseqn&id=';
+        push @queries, $query;
+        $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=ena_sequence&format=fasta&style=raw&Retrieve=Retrieve&id=';
+        push @queries, $query;
+    }
 
     my $response;
     my $concat_response = '';
@@ -99,4 +100,3 @@ sub web_fetch {
 }
 
 Bio::Otter::Server::Support::Web->send_response(\&get_fasta_sequence);
-

--- a/scripts/apache/get_fasta_sequence
+++ b/scripts/apache/get_fasta_sequence
@@ -29,7 +29,7 @@ sub get_fasta_sequence {
     my ($server) = @_;
 
     my $id = $server->require_argument('id');
-    my $seq_target = $server->require_argument('sequence_target');
+    my $seq_type = $server->require_argument('sequence_type');
 
     my @raw_id_array = split (',', $id);
     $id = "";
@@ -42,7 +42,11 @@ sub get_fasta_sequence {
 
     my @queries;
     my $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?format=fasta&style=raw&db=uniprotkb&id=';
-    push @queries, $query;
+
+    if($seq_type eq 'protein') {
+        push @queries, $query;
+    }
+
     $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?format=fasta&style=raw&db=refseqn&id=';
     push @queries, $query;
     $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=ena_sequence&format=fasta&style=raw&Retrieve=Retrieve&id=';
@@ -66,11 +70,6 @@ sub get_fasta_sequence {
 
         if ($i == 0) {
             $cut_id =~ s/\.\d+//;
-        }
-        
-        if($seq_target eq 'dna' && index($queries[$i], 'uniprotkb') != -1 ) {
-            $i++;
-            next;
         }
 
         $response = fetch_ids_from_external_db($queries[$i] . $cut_id);

--- a/scripts/apache/get_fasta_sequence
+++ b/scripts/apache/get_fasta_sequence
@@ -29,6 +29,7 @@ sub get_fasta_sequence {
     my ($server) = @_;
 
     my $id = $server->require_argument('id');
+    my $seq_target = $server->require_argument('sequence_target');
 
     my @raw_id_array = split (',', $id);
     $id = "";
@@ -66,6 +67,11 @@ sub get_fasta_sequence {
         if ($i == 0) {
             $cut_id =~ s/\.\d+//;
         }
+        
+        if($seq_target eq 'dna' && index($queries[$i], 'uniprotkb') != -1 ) {
+            $i++;
+            next;
+        }
 
         $response = fetch_ids_from_external_db($queries[$i] . $cut_id);
         $concat_response = $concat_response . $response;
@@ -94,3 +100,4 @@ sub web_fetch {
 }
 
 Bio::Otter::Server::Support::Web->send_response(\&get_fasta_sequence);
+


### PR DESCRIPTION
## Description

In the current implementation there is no option to specify sequence type (DNA, Protein) to OTF, both sequences were fetched from refseq and uniprot servers. Once both sequences were fetched OTF alignment occurs, as protein sequence cannot be aligned DNA sequence alignment is also failing.

Fix is to add a widget to make sequence selection between DNA and protein to OTF.

![image (14)](https://user-images.githubusercontent.com/13611226/184884983-3bb0b96d-55fb-4275-a341-6483a78a1150.png)

