### PR TITLE
Sequence type selection for OTF

### DIFF
--- a/modules/Bio/Otter/Lace/Client.pm
+++ b/modules/Bio/Otter/Lace/Client.pm
@@ -1181,9 +1181,9 @@ sub _get_DataSets_hash {
 }
 
 sub fetch_fasta_seqence {
-    my ($self, $acc) = @_;
+    my ($self, $acc, $seq_type) = @_;
     my $datasets_hash = $self->otter_response_content
-        ('GET', 'get_fasta_sequence', {'id'=>$acc, 'author' => $self->author});
+        ('GET', 'get_fasta_sequence', {'id'=>$acc, 'sequence_type' => $seq_type, 'author' => $self->author});
 
     return $datasets_hash;
 }

--- a/modules/Bio/Otter/Lace/OnTheFly/QueryValidator.pm
+++ b/modules/Bio/Otter/Lace/OnTheFly/QueryValidator.pm
@@ -261,7 +261,7 @@ sub _fetch_sequences {
           }
 
           if($seq_type eq 'protein' && $type ne 'Protein') {
-              $self->_add_accession_type_warning($acc, " Accession evidence type is $type");
+              $self->_add_accession_type_warning($acc, " Evidence $type and manual $seq_type type mismatch");
               next;
           }
 
@@ -439,7 +439,7 @@ sub _format_warnings {
         my @accession_type = @{$warnings->{accession_type}};
         $accession_type_msg = join("\n", map { sprintf("  %s %s", @{$_}) } @accession_type);
         $accession_type_msg =
-            "The following sequences were fetched, evidence (protein) and manual (dna) type mismatch:\n\n$accession_type_msg\n"
+            "The following sequences were fetched, type mismatch:\n\n$accession_type_msg\n"
     }
 
     if ($warnings->{missing}) {

--- a/modules/Bio/Otter/Lace/OnTheFly/QueryValidator.pm
+++ b/modules/Bio/Otter/Lace/OnTheFly/QueryValidator.pm
@@ -39,6 +39,8 @@ has accession_type_cache => ( is => 'ro', isa => 'Bio::Otter::Lace::AccessionTyp
 has seqs                 => ( is => 'ro', isa => 'ArrayRef[Hum::Sequence]', default => sub{ [] } );
 has accessions           => ( is => 'ro', isa => 'ArrayRef[Str]',           default => sub{ [] } );
 
+has sequence_type      => ( is => 'ro', isa => 'Str', default => 'dna');
+
 has lowercase_poly_a_t_tails => ( is => 'ro', isa => 'Bool', default => undef );
 
 has problem_report_cb    => ( is => 'ro', isa => 'CodeRef', required => 1 );
@@ -95,9 +97,10 @@ sub _build_confirmed_seqs {     ## no critic (Subroutines::ProhibitUnusedPrivate
         $cache->populate(\@accessions);
     }
 
+    my $seq_type = $self->sequence_type;
     $self->_augment_supplied_sequences;
     my @to_fetch = $self->_check_augment_supplied_accessions;
-    $self->_fetch_sequences(@to_fetch);
+    $self->_fetch_sequences($seq_type, @to_fetch);
 
     # tell the user about any missing sequences or remapped accessions
 
@@ -238,7 +241,7 @@ sub Client {
 # Adds sequences to $self->seqs
 #
 sub _fetch_sequences {
-    my ($self, @to_fetch) = @_;
+    my ($self, $seq_type, @to_fetch) = @_;
 
     my $cache = $self->accession_type_cache;
 
@@ -247,7 +250,7 @@ sub _fetch_sequences {
     my $client = Bio::Otter::Lace::Defaults::make_Client();
     foreach my $acc (@to_fetch) {
 
-        my $seq = $client->fetch_fasta_seqence($acc);
+        my $seq = $client->fetch_fasta_seqence($acc, $seq_type);
         if (substr($seq, 0, 1) eq ">") {
           $seq = $self->parse_fasta_sequence($seq);
           push(@{$self->seqs}, $seq);

--- a/modules/Bio/Otter/Lace/OnTheFly/QueryValidator.pm
+++ b/modules/Bio/Otter/Lace/OnTheFly/QueryValidator.pm
@@ -439,7 +439,7 @@ sub _format_warnings {
         my @accession_type = @{$warnings->{accession_type}};
         $accession_type_msg = join("\n", map { sprintf("  %s %s", @{$_}) } @accession_type);
         $accession_type_msg =
-            "The following sequences were fetched, but accession evidence type is not Protein:\n\n$accession_type_msg\n"
+            "The following sequences were fetched, evidence (protein) and manual (dna) type mismatch:\n\n$accession_type_msg\n"
     }
 
     if ($warnings->{missing}) {

--- a/modules/Bio/Otter/UI/OnTheFlyMixin.pm
+++ b/modules/Bio/Otter/UI/OnTheFlyMixin.pm
@@ -27,7 +27,7 @@ sub problem_box {
     $top->messageBox(
         -title   => $Bio::Otter::Lace::Client::PFX.'Problems With ' . $title,
         -icon    => 'warning',
-        -message => $warnings->{missing} . $warnings->{remapped} . $warnings->{unclaimed},
+        -message => $warnings->{missing} . $warnings->{remapped} . $warnings->{unclaimed} . $warnings->{accession_type},
         -type    => 'OK',
         );
     return;

--- a/modules/EditWindow/Exonerate.pm
+++ b/modules/EditWindow/Exonerate.pm
@@ -55,6 +55,10 @@ my $MASK_TARGET_NONE    = 'none';
 my $MASK_TARGET_SOFT    = 'soft';
 my $MASK_TARGET_DEFAULT = $MASK_TARGET_NONE;
 
+my $SEQ_TYPE_PROTEIN   = 'protein';
+my $SEQ_TYPE_DNA    = 'dna';
+my $SEQ_TYPE_DEFAULT = $SEQ_TYPE_DNA;
+
 my $INITIAL_DIR = (getpwuid($<))[7];
 
 sub initialise {
@@ -186,6 +190,11 @@ sub initialise {
            [ 'Unmasked',    $MASK_TARGET_NONE ],
            [ 'Soft masked', $MASK_TARGET_SOFT ],
           ] ],
+        [ '_sequence_type', $SEQ_TYPE_DEFAULT, 'Sequence',
+          [
+           [ 'Protein', $SEQ_TYPE_PROTEIN ],
+           [ 'DNA', $SEQ_TYPE_DNA ],
+          ] ]
         ];
 
     for (@{$input_widgets}) {
@@ -520,6 +529,7 @@ sub launch_exonerate {
         repeat_masker   => sub { my $apply_mask_sub = shift; $self->_repeat_masker($apply_mask_sub); },
 
         softmask_target => ($self->{_mask_target} eq $MASK_TARGET_SOFT),
+        sequence_type => $self->{_sequence_type},
         bestn           => $bestn,
         maxintron       => $maxintron,
 

--- a/scripts/apache/get_fasta_sequence
+++ b/scripts/apache/get_fasta_sequence
@@ -29,6 +29,7 @@ sub get_fasta_sequence {
     my ($server) = @_;
 
     my $id = $server->require_argument('id');
+    my $seq_type = $server->require_argument('sequence_type');
 
     my @raw_id_array = split (',', $id);
     $id = "";
@@ -41,12 +42,16 @@ sub get_fasta_sequence {
 
     my @queries;
     my $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?format=fasta&style=raw&db=uniprotkb&id=';
-    push @queries, $query;
-    $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?format=fasta&style=raw&db=refseqn&id=';
-    push @queries, $query;
-    $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=ena_sequence&format=fasta&style=raw&Retrieve=Retrieve&id=';
+    if($seq_type eq 'protein') {
+        push @queries, $query;
+    }
 
-    push @queries, $query;
+    if($seq_type eq 'dna') {
+        $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?format=fasta&style=raw&db=refseqn&id=';
+        push @queries, $query;
+        $query = 'http://www.ebi.ac.uk/Tools/dbfetch/dbfetch?db=ena_sequence&format=fasta&style=raw&Retrieve=Retrieve&id=';
+        push @queries, $query;
+    }
 
     my $response;
     my $concat_response = '';


### PR DESCRIPTION
We now can choose the sequence type DNA and Protein in the OTF window. If we select DNA sequence type (selected by default) in OTF window then DNA sequence from refseq and ena servers are fetched and aligned. If we select protein then only protein sequence from Uniprot is fetched and aligned.