### PR TITLE
Changed MM DB host

### DIFF
--- a/modules/Bio/Otter/Utils/BulkMM.pm
+++ b/modules/Bio/Otter/Utils/BulkMM.pm
@@ -59,8 +59,8 @@ Readonly my %CLASS_TO_SOURCE => (
     );
 
 Readonly my %DEFAULT_OPTIONS => (
-    host => '45.88.81.151',
-    port => 3306,
+    host => 'mysql-ottermole-mushroom.ebi.ac.uk',
+    port => 4728,
     user => 'mm_readonly',
     name => 'mm_ini',
     db_categories => [ @SEQ_DB_CATEGORIES ],

--- a/modules/Bio/Otter/Utils/MM.pm
+++ b/modules/Bio/Otter/Utils/MM.pm
@@ -63,8 +63,8 @@ Readonly my %CLASS_TO_SOURCE => (
     );
 
 Readonly my %DEFAULT_OPTIONS => (
-    host => '45.88.81.151',
-    port => 3306,
+    host => 'mysql-ottermole-mushroom.ebi.ac.uk',
+    port => 4728,
     user => 'mm_readonly',
     name => 'mm_ini',
     db_categories => [ @DEFAULT_DB_CATEGORIES ],


### PR DESCRIPTION
# Description

This PR is to reconfigure connection details for M&M DB to point to the new DB host.
Pls, see https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-4114

# Test

The Otter test server has already moved to the new host, and it is working fine.
To test all is good - after Otter reboot - it is sufficient to open a region on Zmap.

# Worst case scenario (just in case)

Roll changes back (revert the PR, pull changes, and restart the server)